### PR TITLE
[API] 내 정보 조회 API 추가 및 User 프로필 엔드포인트 경로 정리

### DIFF
--- a/src/main/java/com/sealog/backend/domain/feature/auth/controller/AuthController.java
+++ b/src/main/java/com/sealog/backend/domain/feature/auth/controller/AuthController.java
@@ -6,6 +6,7 @@ import com.sealog.backend.domain.feature.auth.dto.TokenResponse;
 import com.sealog.backend.domain.feature.auth.service.AuthService;
 import com.sealog.backend.global.exception.CustomException;
 import com.sealog.backend.global.response.CustomResponse;
+import com.sealog.backend.security.auth.CustomUserDetails;
 import com.sealog.backend.security.util.CookieUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -13,6 +14,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 /**
@@ -27,6 +29,19 @@ public class AuthController implements AuthControllerDocs {
 
     private final AuthService authService;
     private final CookieUtil cookieUtil;
+
+    /**
+     * 내 정보 조회
+     * GET /api/auth/me
+     * user
+     */
+    @Override
+    @GetMapping("/me")
+    public ResponseEntity<CustomResponse<AuthResponse.AuthProfile>> getMe(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        return ResponseEntity.ok(CustomResponse.success(authService.getMe(userDetails.getUserId())));
+    }
 
     /**
      * 로그인

--- a/src/main/java/com/sealog/backend/domain/feature/auth/controller/AuthControllerDocs.java
+++ b/src/main/java/com/sealog/backend/domain/feature/auth/controller/AuthControllerDocs.java
@@ -3,11 +3,13 @@ package com.sealog.backend.domain.feature.auth.controller;
 import com.sealog.backend.domain.feature.auth.dto.AuthRequest;
 import com.sealog.backend.domain.feature.auth.dto.AuthResponse;
 import com.sealog.backend.global.response.CustomResponse;
+import com.sealog.backend.security.auth.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.security.SecurityRequirements;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
@@ -16,6 +18,15 @@ import org.springframework.http.ResponseEntity;
 
 @Tag(name = "Auth", description = "인증 API")
 public interface AuthControllerDocs {
+
+    @Operation(summary = "내 정보 조회", description = "로그인한 사용자의 인증 프로필을 조회합니다.")
+    @SecurityRequirement(name = "bearerAuth")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패",
+                    content = @Content(schema = @Schema(hidden = true))),
+    })
+    ResponseEntity<CustomResponse<AuthResponse.AuthProfile>> getMe(CustomUserDetails userDetails);
 
     @Operation(summary = "로그인", description = "로그인 후 JWT 발급 (HttpOnly 쿠키로 전달)")
     @SecurityRequirements()

--- a/src/main/java/com/sealog/backend/domain/feature/auth/service/AuthService.java
+++ b/src/main/java/com/sealog/backend/domain/feature/auth/service/AuthService.java
@@ -1,11 +1,20 @@
 package com.sealog.backend.domain.feature.auth.service;
 
 import com.sealog.backend.domain.feature.auth.dto.AuthRequest;
+import com.sealog.backend.domain.feature.auth.dto.AuthResponse;
 import com.sealog.backend.domain.feature.auth.dto.TokenResponse;
 import com.sealog.backend.domain.feature.user.entity.User;
 import com.sealog.backend.global.exception.CustomException;
 
 public interface AuthService {
+
+    /**
+     * 내 정보 조회
+     * @param userId 사용자 ID
+     * @return 사용자 프로필
+     * @throws CustomException 사용자를 찾을 수 없는 경우 (UNAUTHORIZED)
+     */
+    AuthResponse.AuthProfile getMe(Long userId);
 
     /**
      * 로그인

--- a/src/main/java/com/sealog/backend/domain/feature/auth/service/AuthServiceImpl.java
+++ b/src/main/java/com/sealog/backend/domain/feature/auth/service/AuthServiceImpl.java
@@ -27,6 +27,12 @@ public class AuthServiceImpl implements AuthService {
     private final JwtTokenProvider jwtTokenProvider;
 
     @Override
+    public AuthResponse.AuthProfile getMe(Long userId) {
+        User user = getUserById(userId);
+        return AuthResponse.AuthProfile.from(user);
+    }
+
+    @Override
     @Transactional
     public TokenResponse login(AuthRequest.Login request) {
         // 이메일로 사용자 조회

--- a/src/main/java/com/sealog/backend/domain/feature/user/controller/UserGuestController.java
+++ b/src/main/java/com/sealog/backend/domain/feature/user/controller/UserGuestController.java
@@ -15,11 +15,11 @@ public class UserGuestController implements UserGuestControllerDocs {
     private final UserService userService;
 
     /**
-     * 특정 사용자 정보 조회
-     * GET /api/guest/user/{nickname}
+     * 특정 사용자 프로필 정보 조회
+     * GET /api/guest/user/{nickname}/profile
      */
     @Override
-    @GetMapping("/{nickname}")
+    @GetMapping("/{nickname}/profile")
     public ResponseEntity<CustomResponse<UserResponse.PublicProfile>> getBlogUserInfo(
             @PathVariable String nickname
     ) {

--- a/src/main/java/com/sealog/backend/domain/feature/user/controller/UserMeController.java
+++ b/src/main/java/com/sealog/backend/domain/feature/user/controller/UserMeController.java
@@ -21,12 +21,12 @@ public class UserMeController implements UserMeControllerDocs {
     private final UserService userService;
 
     /**
-     * 내 정보 조회
-     * GET /api/user/me
+     * 내 프로필 조회
+     * GET /api/user/me/profile
      * user
      */
     @Override
-    @GetMapping
+    @GetMapping("/profile")
     public ResponseEntity<CustomResponse<UserResponse.MyProfile>> getMyInfo(
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {

--- a/src/main/java/com/sealog/backend/security/config/SecurityConfig.java
+++ b/src/main/java/com/sealog/backend/security/config/SecurityConfig.java
@@ -69,6 +69,7 @@ public class SecurityConfig {
                 // URL별 접근 권한 설정
                 .authorizeHttpRequests(authorize -> authorize
                         // 인증 없이 접근 가능한 경로
+                        .requestMatchers(HttpMethod.GET, "/api/auth/me").authenticated()
                         .requestMatchers("/api/auth/**").permitAll()
                         .requestMatchers("/api/admin/**").hasRole("ADMIN")
                         .requestMatchers("/api/user/**").hasRole("USER")


### PR DESCRIPTION
[feat] GET /api/auth/me 엔드포인트 추가(로그인 상태용)
- AuthService.getMe, AuthServiceImpl 구현
- AuthControllerDocs Swagger 스펙 추가

[refactor] User 프로필 API 경로 명시화
- GET /api/user/me → /api/user/me/profile
- GET /api/guest/user/{nickname} → /api/guest/user/{nickname}/profile