### PR TITLE
[Archive] 서비스 메서드명 및 DTO 내부 클래스명 컨벤션 적용

### DIFF
--- a/src/main/java/com/sealog/backend/domain/feature/archive/controller/ArchiveUserController.java
+++ b/src/main/java/com/sealog/backend/domain/feature/archive/controller/ArchiveUserController.java
@@ -74,11 +74,11 @@ public class ArchiveUserController implements ArchiveUserControllerDocs {
      */
     @Override
     @PostMapping
-    public ResponseEntity<CustomResponse<Void>> add(
+    public ResponseEntity<CustomResponse<Void>> create(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @RequestBody @Valid ArchiveRequest.Add request
+            @RequestBody @Valid ArchiveRequest.Create request
     ) {
-        archiveService.add(userDetails.getUserId(), request);
+        archiveService.create(userDetails.getUserId(), request);
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(CustomResponse.success(null, "아카이브가 생성되었습니다"));
@@ -90,13 +90,13 @@ public class ArchiveUserController implements ArchiveUserControllerDocs {
      */
     @Override
     @PutMapping("/{nickname}/{slug}")
-    public ResponseEntity<CustomResponse<Void>> edit(
+    public ResponseEntity<CustomResponse<Void>> update(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable String nickname,
             @PathVariable String slug,
-            @RequestBody @Valid ArchiveRequest.Edit request
+            @RequestBody @Valid ArchiveRequest.Update request
     ) {
-        archiveService.edit(userDetails.getUserId(), nickname, slug, request);
+        archiveService.update(userDetails.getUserId(), nickname, slug, request);
         return ResponseEntity.ok(CustomResponse.success(null, "아카이브가 수정되었습니다"));
     }
 
@@ -136,12 +136,12 @@ public class ArchiveUserController implements ArchiveUserControllerDocs {
      */
     @Override
     @DeleteMapping("/{nickname}/{slug}")
-    public ResponseEntity<CustomResponse<Void>> remove(
+    public ResponseEntity<CustomResponse<Void>> delete(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable String nickname,
             @PathVariable String slug
     ) {
-        archiveService.remove(userDetails.getUserId(), nickname, slug);
+        archiveService.delete(userDetails.getUserId(), nickname, slug);
         return ResponseEntity.ok(CustomResponse.success(null, "아카이브가 삭제되었습니다"));
     }
 
@@ -168,11 +168,11 @@ public class ArchiveUserController implements ArchiveUserControllerDocs {
      */
     @Override
     @DeleteMapping("/post/{postId}")
-    public ResponseEntity<CustomResponse<Void>> removePostArchive(
+    public ResponseEntity<CustomResponse<Void>> deletePostArchive(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable Long postId
     ) {
-        archiveService.removePostArchive(userDetails.getUserId(), postId);
+        archiveService.deletePostArchive(userDetails.getUserId(), postId);
         return ResponseEntity.ok(CustomResponse.success(null, "게시글 아카이브 배정이 해제되었습니다"));
     }
 }

--- a/src/main/java/com/sealog/backend/domain/feature/archive/controller/ArchiveUserControllerDocs.java
+++ b/src/main/java/com/sealog/backend/domain/feature/archive/controller/ArchiveUserControllerDocs.java
@@ -69,9 +69,9 @@ public interface ArchiveUserControllerDocs {
             @ApiResponse(responseCode = "401", description = "인증 실패",
                     content = @Content(schema = @Schema(hidden = true)))
     })
-    ResponseEntity<CustomResponse<Void>> add(
+    ResponseEntity<CustomResponse<Void>> create(
             @Parameter(hidden = true) CustomUserDetails userDetails,
-            ArchiveRequest.Add request
+            ArchiveRequest.Create request
     );
 
     @Operation(
@@ -87,11 +87,11 @@ public interface ArchiveUserControllerDocs {
             @ApiResponse(responseCode = "403", description = "권한 없음 (소유자 아님)",
                     content = @Content(schema = @Schema(hidden = true)))
     })
-    ResponseEntity<CustomResponse<Void>> edit(
+    ResponseEntity<CustomResponse<Void>> update(
             @Parameter(hidden = true) CustomUserDetails userDetails,
             @Parameter(description = "소유자 닉네임", example = "테스터") String nickname,
             @Parameter(description = "아카이브 slug", example = "spring-boot-study") String slug,
-            ArchiveRequest.Edit request
+            ArchiveRequest.Update request
     );
 
     @Operation(
@@ -139,7 +139,7 @@ public interface ArchiveUserControllerDocs {
             @ApiResponse(responseCode = "403", description = "권한 없음 (소유자 아님)",
                     content = @Content(schema = @Schema(hidden = true)))
     })
-    ResponseEntity<CustomResponse<Void>> remove(
+    ResponseEntity<CustomResponse<Void>> delete(
             @Parameter(hidden = true) CustomUserDetails userDetails,
             @Parameter(description = "소유자 닉네임", example = "테스터") String nickname,
             @Parameter(description = "아카이브 slug", example = "spring-boot-study") String slug
@@ -173,7 +173,7 @@ public interface ArchiveUserControllerDocs {
             @ApiResponse(responseCode = "403", description = "권한 없음 (게시글 소유자 아님)",
                     content = @Content(schema = @Schema(hidden = true)))
     })
-    ResponseEntity<CustomResponse<Void>> removePostArchive(
+    ResponseEntity<CustomResponse<Void>> deletePostArchive(
             @Parameter(hidden = true) CustomUserDetails userDetails,
             @Parameter(description = "해제할 게시글 ID", example = "1") Long postId
     );

--- a/src/main/java/com/sealog/backend/domain/feature/archive/dto/ArchiveRequest.java
+++ b/src/main/java/com/sealog/backend/domain/feature/archive/dto/ArchiveRequest.java
@@ -20,8 +20,8 @@ public class ArchiveRequest {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    @Schema(description = "아카이브 생성 요청")
-    public static class Add {
+    @Schema(name = "ArchiveCreate", description = "아카이브 생성 요청")
+    public static class Create {
 
         @CheckStringSize(max = 100)
         @Schema(description = "이름", example = "Spring Boot 프로젝트", maxLength = 100)
@@ -35,8 +35,8 @@ public class ArchiveRequest {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    @Schema(description = "아카이브 수정 요청")
-    public static class Edit {
+    @Schema(name = "ArchiveUpdate", description = "아카이브 수정 요청")
+    public static class Update {
 
         @CheckStringSize(max = 100)
         @Schema(description = "이름", example = "Spring Boot 프로젝트", maxLength = 100)

--- a/src/main/java/com/sealog/backend/domain/feature/archive/dto/ArchiveResponse.java
+++ b/src/main/java/com/sealog/backend/domain/feature/archive/dto/ArchiveResponse.java
@@ -38,7 +38,7 @@ public class ArchiveResponse {
     @Builder
     @NoArgsConstructor(access = AccessLevel.PRIVATE)
     @AllArgsConstructor(access = AccessLevel.PRIVATE)
-    @Schema(description = "아카이브에 속하는 블로그 게시글 목록 조회")
+    @Schema(name = "ArchivePostItem", description = "아카이브에 속하는 블로그 게시글 목록 조회")
     public static class PostItems {
 
         private Long postId;

--- a/src/main/java/com/sealog/backend/domain/feature/archive/service/ArchiveService.java
+++ b/src/main/java/com/sealog/backend/domain/feature/archive/service/ArchiveService.java
@@ -64,7 +64,7 @@ public interface ArchiveService {
      * @param request 생성 요청 데이터
      * @throws CustomException 사용자 없음, 동일 이름 이미 존재
      */
-    void add(Long userId, ArchiveRequest.Add request);
+    void create(Long userId, ArchiveRequest.Create request);
 
     /**
      * 아카이브 이름 수정
@@ -76,7 +76,7 @@ public interface ArchiveService {
      * @param request  수정 요청 데이터
      * @throws CustomException 아카이브 없음, 권한 없음, 동일 이름으로 수정 시도
      */
-    void edit(Long userId, String nickname, String slug, ArchiveRequest.Edit request);
+    void update(Long userId, String nickname, String slug, ArchiveRequest.Update request);
 
     /**
      * 아카이브 공개 처리
@@ -106,7 +106,7 @@ public interface ArchiveService {
      * @param slug     삭제할 아카이브 slug
      * @throws CustomException 아카이브 없음, 권한 없음
      */
-    void remove(Long userId, String nickname, String slug);
+    void delete(Long userId, String nickname, String slug);
 
     /**
      * 게시글의 소속 아카이브 변경 (배정/재배정)
@@ -127,6 +127,6 @@ public interface ArchiveService {
      * @param postId 해제 대상 게시글 ID
      * @throws CustomException 게시글 없음, 권한 없음
      */
-    void removePostArchive(Long userId, Long postId);
+    void deletePostArchive(Long userId, Long postId);
 
 }

--- a/src/main/java/com/sealog/backend/domain/feature/archive/service/ArchiveServiceImpl.java
+++ b/src/main/java/com/sealog/backend/domain/feature/archive/service/ArchiveServiceImpl.java
@@ -68,7 +68,7 @@ public class ArchiveServiceImpl implements ArchiveService {
 
     @Transactional
     @Override
-    public void add(Long userId, ArchiveRequest.Add request) {
+    public void create(Long userId, ArchiveRequest.Create request) {
 
         // 1. 회원 엔티티 조회
         User user = userRepository
@@ -97,7 +97,7 @@ public class ArchiveServiceImpl implements ArchiveService {
 
     @Transactional
     @Override
-    public void edit(Long userId, String nickname, String slug, ArchiveRequest.Edit request) {
+    public void update(Long userId, String nickname, String slug, ArchiveRequest.Update request) {
 
         // 1. entity 조회
         Archive archive = findArchiveByNicknameAndSlug(nickname, slug);
@@ -149,7 +149,7 @@ public class ArchiveServiceImpl implements ArchiveService {
 
     @Transactional
     @Override
-    public void remove(Long userId, String nickname, String slug) {
+    public void delete(Long userId, String nickname, String slug) {
 
         // 1. 조회 및 검증
         Archive archive = findArchiveByNicknameAndSlug(nickname, slug);
@@ -177,7 +177,7 @@ public class ArchiveServiceImpl implements ArchiveService {
 
     @Transactional
     @Override
-    public void removePostArchive(Long userId, Long postId) {
+    public void deletePostArchive(Long userId, Long postId) {
 
         // 1. Post 조회 및 검증
         Post post = findPostById(postId);

--- a/src/test/java/com/sealog/backend/domain/feature/archive/integration/ArchiveIntegrationTest.java
+++ b/src/test/java/com/sealog/backend/domain/feature/archive/integration/ArchiveIntegrationTest.java
@@ -167,7 +167,7 @@ class ArchiveIntegrationTest extends TestIntegrationBase {
         @Test
         @DisplayName("성공 → 201")
         void 성공() throws Exception {
-            ArchiveRequest.Add request = ArchiveRequest.Add.builder()
+            ArchiveRequest.Create request = ArchiveRequest.Create.builder()
                     .name("새로운 아카이브")
                     .build();
 
@@ -182,7 +182,7 @@ class ArchiveIntegrationTest extends TestIntegrationBase {
         @Test
         @DisplayName("실패 - 이름 중복 → 400")
         void 이름_중복() throws Exception {
-            ArchiveRequest.Add request = ArchiveRequest.Add.builder()
+            ArchiveRequest.Create request = ArchiveRequest.Create.builder()
                     .name(testArchive.getName())
                     .build();
 
@@ -196,7 +196,7 @@ class ArchiveIntegrationTest extends TestIntegrationBase {
         @Test
         @DisplayName("실패 - 미인증 → 401")
         void 미인증() throws Exception {
-            ArchiveRequest.Add request = ArchiveRequest.Add.builder()
+            ArchiveRequest.Create request = ArchiveRequest.Create.builder()
                     .name("새로운 아카이브")
                     .build();
 
@@ -218,7 +218,7 @@ class ArchiveIntegrationTest extends TestIntegrationBase {
         @Test
         @DisplayName("성공 → 200")
         void 성공() throws Exception {
-            ArchiveRequest.Edit request = ArchiveRequest.Edit.builder()
+            ArchiveRequest.Update request = ArchiveRequest.Update.builder()
                     .name("수정된 이름")
                     .build();
 
@@ -233,7 +233,7 @@ class ArchiveIntegrationTest extends TestIntegrationBase {
         @Test
         @DisplayName("실패 - 같은 이름으로 수정 → 400")
         void 같은_이름() throws Exception {
-            ArchiveRequest.Edit request = ArchiveRequest.Edit.builder()
+            ArchiveRequest.Update request = ArchiveRequest.Update.builder()
                     .name(testArchive.getName())
                     .build();
 
@@ -247,7 +247,7 @@ class ArchiveIntegrationTest extends TestIntegrationBase {
         @Test
         @DisplayName("실패 - 다른 아카이브와 이름 중복 → 409")
         void 이름_중복() throws Exception {
-            ArchiveRequest.Edit request = ArchiveRequest.Edit.builder()
+            ArchiveRequest.Update request = ArchiveRequest.Update.builder()
                     .name(privateArchive.getName())
                     .build();
 
@@ -261,7 +261,7 @@ class ArchiveIntegrationTest extends TestIntegrationBase {
         @Test
         @DisplayName("실패 - 타인 아카이브 수정 → 403")
         void 권한_없음() throws Exception {
-            ArchiveRequest.Edit request = ArchiveRequest.Edit.builder()
+            ArchiveRequest.Update request = ArchiveRequest.Update.builder()
                     .name("수정된 이름")
                     .build();
 


### PR DESCRIPTION
[refactor] 서비스/컨트롤러 메서드명 표준화
* add() → create(), edit() → update(), remove() → delete()
* removePostArchive() → deletePostArchive()

[refactor] DTO 내부 클래스명 표준화
* ArchiveRequest.Add → Create, Edit → Update
* @Schema name 속성 추가 (ArchiveRequest, ArchiveResponse)