### PR TITLE
[Post] PostStack 영속 테스트 추가 및 영속 테스트 기능 변경, Post 검색 기능 추가 및 리펙토링

### DIFF
--- a/src/main/java/com/sealog/backend/domain/feature/post/controller/PostGuestController.java
+++ b/src/main/java/com/sealog/backend/domain/feature/post/controller/PostGuestController.java
@@ -12,8 +12,6 @@ import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-
 /**
  * 공개 게시글 컨트롤러 (인증 불필요)
  *
@@ -68,19 +66,37 @@ public class PostGuestController implements PostGuestControllerDocs {
         return ResponseEntity.ok(CustomResponse.success(PageResponse.from(posts)));
     }
 
+
     /**
-     * 게시글 자동완성 검색
-     * GET /api/guest/posts/autocomplete?keyword=검색어
+     * 스택별 공개 게시글 목록 조회
+     * GET /api/guest/posts?stackName={stackName}
      *
-     * - PUBLISHED 상태만 검색
-     * - 최대 10개 반환
+     * - PUBLISHED 상태만 조회
      */
     @Override
-    @GetMapping("/posts/autocomplete")
-    public ResponseEntity<CustomResponse<List<PostResponse.PostItems>>> autocomplete(
-            @RequestParam(required = false, defaultValue = "") String keyword
+    @GetMapping(value = "/posts", params = "stackName")
+    public ResponseEntity<CustomResponse<PageResponse<PostResponse.PostItems>>> getPostsByStack(
+            @RequestParam String stackName,
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
     ) {
-        List<PostResponse.PostItems> results = postService.autocomplete(keyword);
-        return ResponseEntity.ok(CustomResponse.success(results));
+        Page<PostResponse.PostItems> posts = postService.getPostsByStack(stackName, pageable);
+        return ResponseEntity.ok(CustomResponse.success(PageResponse.from(posts)));
+    }
+
+
+    /**
+     * 공개 게시글 검색
+     * GET /api/guest/posts/search?keyword=검색어
+     *
+     * - PUBLISHED 상태만 검색
+     */
+    @Override
+    @GetMapping("/posts/search")
+    public ResponseEntity<CustomResponse<PageResponse<PostResponse.PostItems>>> searchPosts(
+            @RequestParam(required = false, defaultValue = "") String keyword,
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        Page<PostResponse.PostItems> results = postService.searchPosts(null, keyword, pageable);
+        return ResponseEntity.ok(CustomResponse.success(PageResponse.from(results)));
     }
 }

--- a/src/main/java/com/sealog/backend/domain/feature/post/controller/PostGuestController.java
+++ b/src/main/java/com/sealog/backend/domain/feature/post/controller/PostGuestController.java
@@ -68,21 +68,21 @@ public class PostGuestController implements PostGuestControllerDocs {
 
 
     /**
-     * 스택별 공개 게시글 목록 조회
-     * GET /api/guest/posts?stackName={stackName}
+     * 특정 사용자의 스택별 공개 게시글 목록 조회
+     * GET /api/guest/{nickname}/posts?stackName={stackName}
      *
      * - PUBLISHED 상태만 조회
      */
     @Override
-    @GetMapping(value = "/posts", params = "stackName")
+    @GetMapping(value = "/{nickname}/posts", params = "stackName")
     public ResponseEntity<CustomResponse<PageResponse<PostResponse.PostItems>>> getPostsByStack(
+            @PathVariable String nickname,
             @RequestParam String stackName,
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
     ) {
-        Page<PostResponse.PostItems> posts = postService.getPostsByStack(stackName, pageable);
+        Page<PostResponse.PostItems> posts = postService.getPostsByStack(nickname, stackName, pageable);
         return ResponseEntity.ok(CustomResponse.success(PageResponse.from(posts)));
     }
-
 
     /**
      * 공개 게시글 검색
@@ -97,6 +97,23 @@ public class PostGuestController implements PostGuestControllerDocs {
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
     ) {
         Page<PostResponse.PostItems> results = postService.searchPosts(null, keyword, pageable);
+        return ResponseEntity.ok(CustomResponse.success(PageResponse.from(results)));
+    }
+
+    /**
+     * 특정 사용자의 공개 게시글 검색
+     * GET /api/guest/{nickname}/posts/search?keyword=검색어
+     *
+     * - PUBLISHED 상태만 검색
+     */
+    @Override
+    @GetMapping("/{nickname}/posts/search")
+    public ResponseEntity<CustomResponse<PageResponse<PostResponse.PostItems>>> searchPostsByNickname(
+            @PathVariable String nickname,
+            @RequestParam(required = false, defaultValue = "") String keyword,
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        Page<PostResponse.PostItems> results = postService.searchPostsByNickname(nickname, keyword, pageable);
         return ResponseEntity.ok(CustomResponse.success(PageResponse.from(results)));
     }
 }

--- a/src/main/java/com/sealog/backend/domain/feature/post/controller/PostGuestControllerDocs.java
+++ b/src/main/java/com/sealog/backend/domain/feature/post/controller/PostGuestControllerDocs.java
@@ -46,20 +46,31 @@ public interface PostGuestControllerDocs {
             Pageable pageable
     );
 
-    @Operation(summary = "스택별 게시글 목록 조회", description = "stackName으로 PUBLISHED 게시글 목록을 조회합니다.")
+    @Operation(summary = "유저의 스택별 게시글 목록 조회", description = "nickname 기준으로 stackName에 해당하는 PUBLISHED 게시글 목록을 조회합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
     })
     ResponseEntity<CustomResponse<PageResponse<PostResponse.PostItems>>> getPostsByStack(
+            @Parameter(description = "사용자 닉네임", example = "테스터") String nickname,
             @Parameter(description = "스택 이름", example = "Java") String stackName,
             Pageable pageable
     );
 
-    @Operation(summary = "공개 게시글 검색", description = "keyword로 PUBLISHED 게시글을 검색합니다.")
+    @Operation(summary = "공개 게시글 검색", description = "keyword로 전체 PUBLISHED 게시글을 검색합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
     })
     ResponseEntity<CustomResponse<PageResponse<PostResponse.PostItems>>> searchPosts(
+            @Parameter(description = "검색 키워드", example = "spring") String keyword,
+            Pageable pageable
+    );
+
+    @Operation(summary = "유저의 공개 게시글 검색", description = "nickname 기준으로 keyword에 해당하는 PUBLISHED 게시글을 검색합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+    })
+    ResponseEntity<CustomResponse<PageResponse<PostResponse.PostItems>>> searchPostsByNickname(
+            @Parameter(description = "사용자 닉네임", example = "테스터") String nickname,
             @Parameter(description = "검색 키워드", example = "spring") String keyword,
             Pageable pageable
     );

--- a/src/main/java/com/sealog/backend/domain/feature/post/controller/PostGuestControllerDocs.java
+++ b/src/main/java/com/sealog/backend/domain/feature/post/controller/PostGuestControllerDocs.java
@@ -14,8 +14,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 
-import java.util.List;
-
 @Tag(name = "Post", description = "공개 게시글 API (인증 불필요)")
 @SecurityRequirements()
 public interface PostGuestControllerDocs {
@@ -48,11 +46,21 @@ public interface PostGuestControllerDocs {
             Pageable pageable
     );
 
-    @Operation(summary = "게시글 자동완성", description = "keyword로 자동완성 검색(최대 10개)을 수행합니다.")
+    @Operation(summary = "스택별 게시글 목록 조회", description = "stackName으로 PUBLISHED 게시글 목록을 조회합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
     })
-    ResponseEntity<CustomResponse<List<PostResponse.PostItems>>> autocomplete(
-            @Parameter(description = "검색 키워드", example = "spring") String keyword
+    ResponseEntity<CustomResponse<PageResponse<PostResponse.PostItems>>> getPostsByStack(
+            @Parameter(description = "스택 이름", example = "Java") String stackName,
+            Pageable pageable
+    );
+
+    @Operation(summary = "공개 게시글 검색", description = "keyword로 PUBLISHED 게시글을 검색합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+    })
+    ResponseEntity<CustomResponse<PageResponse<PostResponse.PostItems>>> searchPosts(
+            @Parameter(description = "검색 키워드", example = "spring") String keyword,
+            Pageable pageable
     );
 }

--- a/src/main/java/com/sealog/backend/domain/feature/post/controller/PostUserController.java
+++ b/src/main/java/com/sealog/backend/domain/feature/post/controller/PostUserController.java
@@ -130,7 +130,7 @@ public class PostUserController implements PostUserControllerDocs {
             @RequestParam(required = false, defaultValue = "") String keyword,
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
     ) {
-        Page<PostResponse.PostItems> results = postService.searchPosts(userDetails.getUserId(), keyword, pageable);
+        Page<PostResponse.PostItems> results = postService.searchPosts(userDetails.getUser().getNickname(), keyword, pageable);
         return ResponseEntity.ok(CustomResponse.success(PageResponse.from(results)));
     }
 

--- a/src/main/java/com/sealog/backend/domain/feature/post/controller/PostUserController.java
+++ b/src/main/java/com/sealog/backend/domain/feature/post/controller/PostUserController.java
@@ -118,6 +118,23 @@ public class PostUserController implements PostUserControllerDocs {
     // ========== 조회 ========== //
 
     /**
+     * 내 게시글 검색
+     * GET /api/user/posts/search?keyword=검색어
+     *
+     * - PUBLISHED + DRAFT 상태 포함, 본인 게시글만
+     */
+    @Override
+    @GetMapping("/posts/search")
+    public ResponseEntity<CustomResponse<PageResponse<PostResponse.PostItems>>> searchPosts(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(required = false, defaultValue = "") String keyword,
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        Page<PostResponse.PostItems> results = postService.searchPosts(userDetails.getUserId(), keyword, pageable);
+        return ResponseEntity.ok(CustomResponse.success(PageResponse.from(results)));
+    }
+
+    /**
      * 삭제된 게시글 목록 조회
      * GET /api/user/posts/deleted
      */

--- a/src/main/java/com/sealog/backend/domain/feature/post/controller/PostUserControllerDocs.java
+++ b/src/main/java/com/sealog/backend/domain/feature/post/controller/PostUserControllerDocs.java
@@ -102,6 +102,18 @@ public interface PostUserControllerDocs {
             @Parameter(description = "게시글 ID", example = "1") Long postId
     );
 
+    @Operation(summary = "내 게시글 검색", description = "keyword로 본인의 게시글(PUBLISHED + DRAFT)을 검색합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패",
+                    content = @Content(schema = @Schema(hidden = true))),
+    })
+    ResponseEntity<CustomResponse<PageResponse<PostResponse.PostItems>>> searchPosts(
+            CustomUserDetails userDetails,
+            @Parameter(description = "검색 키워드", example = "spring") String keyword,
+            Pageable pageable
+    );
+
     @Operation(summary = "삭제된 내 게시글 목록 조회", description = "소프트 삭제된 게시글 목록을 조회합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),

--- a/src/main/java/com/sealog/backend/domain/feature/post/dto/PostResponse.java
+++ b/src/main/java/com/sealog/backend/domain/feature/post/dto/PostResponse.java
@@ -73,6 +73,7 @@ public class PostResponse {
         private List<String> tags;
         private List<StackItem> stacks;
         private AuthorInfo author;
+        private String archiveSlug;
         private LocalDateTime createdAt;
         private LocalDateTime updatedAt;
 
@@ -87,6 +88,7 @@ public class PostResponse {
                 List<String> tags,
                 List<StackItem> stacks,
                 AuthorInfo author,
+                String archiveSlug,
                 LocalDateTime createdAt,
                 LocalDateTime updatedAt
         ) {
@@ -101,6 +103,7 @@ public class PostResponse {
                     .tags(tags)
                     .stacks(stacks)
                     .author(author)
+                    .archiveSlug(archiveSlug)
                     .createdAt(createdAt)
                     .updatedAt(updatedAt)
                     .build();

--- a/src/main/java/com/sealog/backend/domain/feature/post/dto/PostResponse.java
+++ b/src/main/java/com/sealog/backend/domain/feature/post/dto/PostResponse.java
@@ -74,6 +74,7 @@ public class PostResponse {
         private List<StackItem> stacks;
         private AuthorInfo author;
         private String archiveSlug;
+        private String archiveName;
         private LocalDateTime createdAt;
         private LocalDateTime updatedAt;
 
@@ -89,6 +90,7 @@ public class PostResponse {
                 List<StackItem> stacks,
                 AuthorInfo author,
                 String archiveSlug,
+                String archiveName,
                 LocalDateTime createdAt,
                 LocalDateTime updatedAt
         ) {
@@ -104,6 +106,7 @@ public class PostResponse {
                     .stacks(stacks)
                     .author(author)
                     .archiveSlug(archiveSlug)
+                    .archiveName(archiveName)
                     .createdAt(createdAt)
                     .updatedAt(updatedAt)
                     .build();

--- a/src/main/java/com/sealog/backend/domain/feature/post/repository/PostRepository.java
+++ b/src/main/java/com/sealog/backend/domain/feature/post/repository/PostRepository.java
@@ -98,13 +98,15 @@ public interface PostRepository extends JpaRepository<Post, Long>, JpaSpecificat
     // ========== 스택 기반 조회 ========== //
 
     /**
-     * 스택 이름으로 PUBLISHED 게시글 목록 조회
+     * 닉네임 + 스택 이름으로 특정 유저의 PUBLISHED 게시글 목록 조회
      * 조인으로만 작성 시, DISTINCT가 필요하므로 페이징 쿼리 불가능
      */
     @Query("""
         SELECT p
         FROM Post p
-        WHERE p.status = 'PUBLISHED'
+        JOIN FETCH p.user u
+        WHERE u.nickname = :nickname
+          AND p.status = 'PUBLISHED'
           AND p.deletedAt IS NULL
           AND EXISTS (
               SELECT 1
@@ -113,7 +115,7 @@ public interface PostRepository extends JpaRepository<Post, Long>, JpaSpecificat
                 AND ps.stack.name = :stackName
           )
     """)
-    Page<Post> findPublishedByStackName(@Param("stackName") String stackName, Pageable pageable);
+    Page<Post> findPublishedByNicknameAndStackName(@Param("nickname") String nickname, @Param("stackName") String stackName, Pageable pageable);
 
     // ========== 아카이브 기반 조회 ========== //
 

--- a/src/main/java/com/sealog/backend/domain/feature/post/repository/PostRepository.java
+++ b/src/main/java/com/sealog/backend/domain/feature/post/repository/PostRepository.java
@@ -62,29 +62,19 @@ public interface PostRepository extends JpaRepository<Post, Long>, JpaSpecificat
     /**
      * 닉네임 + slug로 공개 게시글 상세 조회
      * - PUBLISHED 상태 + 삭제되지 않은 게시글
+     * - archive는 nullable이므로 LEFT JOIN FETCH 사용
      */
-    @Query("SELECT p FROM Post p " +
-            "JOIN FETCH p.user u " +
-            "WHERE u.nickname = :nickname " +
-            "AND p.slug = :slug " +
-            "AND p.status = 'PUBLISHED' " +
-            "AND p.deletedAt IS NULL")
+    @Query("""
+        SELECT p
+        FROM Post p
+        JOIN FETCH p.user u
+        LEFT JOIN FETCH p.archive
+        WHERE u.nickname = :nickname
+          AND p.slug = :slug
+          AND p.status = 'PUBLISHED'
+          AND p.deletedAt IS NULL
+    """)
     Optional<Post> findPublishedByNicknameAndSlug(@Param("nickname") String nickname, @Param("slug") String slug);
-
-    /**
-     * 키워드로 공개 게시글 자동완성 검색
-     * - 제목 우선 매칭, PUBLISHED + 삭제되지 않은 게시글
-     * - Pageable로 최대 개수 제한 (서비스에서 PageRequest.of(0, 10) 전달)
-     */
-    @Query("SELECT p FROM Post p " +
-            "JOIN FETCH p.user " +
-            "WHERE p.status = 'PUBLISHED' " +
-            "AND p.deletedAt IS NULL " +
-            "AND (p.title LIKE %:keyword% OR p.excerpt LIKE %:keyword%) " +
-            "ORDER BY " +
-            "CASE WHEN p.title LIKE %:keyword% THEN 0 ELSE 1 END, " +
-            "p.createdAt DESC")
-    List<Post> findPublishedByKeyword(@Param("keyword") String keyword, Pageable pageable);
 
     // ========== 내 게시글 조회 (인증) ========== //
 
@@ -104,6 +94,26 @@ public interface PostRepository extends JpaRepository<Post, Long>, JpaSpecificat
             "AND p.deletedAt IS NOT NULL")
     Page<Post> findDeletedPostsByUserId(@Param("userId") Long userId, Pageable pageable);
 
+
+    // ========== 스택 기반 조회 ========== //
+
+    /**
+     * 스택 이름으로 PUBLISHED 게시글 목록 조회
+     * 조인으로만 작성 시, DISTINCT가 필요하므로 페이징 쿼리 불가능
+     */
+    @Query("""
+        SELECT p
+        FROM Post p
+        WHERE p.status = 'PUBLISHED'
+          AND p.deletedAt IS NULL
+          AND EXISTS (
+              SELECT 1
+              FROM PostStack ps
+              WHERE ps.post = p
+                AND ps.stack.name = :stackName
+          )
+    """)
+    Page<Post> findPublishedByStackName(@Param("stackName") String stackName, Pageable pageable);
 
     // ========== 아카이브 기반 조회 ========== //
 

--- a/src/main/java/com/sealog/backend/domain/feature/post/repository/condition/PostCondition.java
+++ b/src/main/java/com/sealog/backend/domain/feature/post/repository/condition/PostCondition.java
@@ -12,8 +12,9 @@ import java.util.Objects;
  *
  * 사용 목적:
  * - Guest/User 역할별 동적 조건 조합
- * - requesterId = null → Guest (PUBLISHED만, 전체 사용자)
- * - requesterId != null → User (전체 상태, 본인 게시글만)
+ * - nickname = null  → Guest (PUBLISHED만, 전체 사용자)
+ * - nickname != null → User (전체 상태, 닉네임 일치 사용자만)
+ * - searchByNickname → 특정 사용자의 PUBLISHED 게시글만 (공개 검색)
  */
 @UtilityClass
 public class PostCondition {
@@ -22,16 +23,33 @@ public class PostCondition {
      * 게시글 검색 조건 조합
      * - 삭제되지 않은 게시글 + 키워드 매칭 + 역할별 조건
      *
-     * @param requesterId 요청자 ID (null = Guest, non-null = User)
-     * @param keyword     검색 키워드
+     * @param nickname 요청자 닉네임 (null = Guest, non-null = User)
+     * @param keyword  검색 키워드
      * @return 조합된 Specification
      */
-    public static Specification<Post> search(Long requesterId, String keyword) {
+    public static Specification<Post> search(String nickname, String keyword) {
         return Specification.allOf(
                 notDeleted(),
                 keywordContains(keyword),
-                onlyPublishedIfGuest(requesterId),
-                ownedByUser(requesterId)
+                onlyPublishedIfNicknameAbsent(nickname),
+                nicknameEquals(nickname)
+        );
+    }
+
+    /**
+     * 특정 사용자의 공개 게시글 검색 조건 조합
+     * - 삭제되지 않은 게시글 + PUBLISHED + 닉네임 일치 + 키워드 매칭
+     *
+     * @param nickname 검색 대상 사용자 닉네임
+     * @param keyword  검색 키워드
+     * @return 조합된 Specification
+     */
+    public static Specification<Post> searchByNickname(String nickname, String keyword) {
+        return Specification.allOf(
+                notDeleted(),
+                keywordContains(keyword),
+                onlyPublished(),
+                nicknameEquals(nickname)
         );
     }
 
@@ -55,22 +73,29 @@ public class PostCondition {
     }
 
     /**
-     * Guest인 경우 PUBLISHED 상태만 (User는 조건 없음 → 전체 상태)
+     * nickname이 없는 경우(Guest) PUBLISHED 상태만 (nickname 존재 시 조건 없음 → 전체 상태)
      */
-    private static Specification<Post> onlyPublishedIfGuest(Long requesterId) {
+    private static Specification<Post> onlyPublishedIfNicknameAbsent(String nickname) {
         return (root, query, cb) ->
-                Objects.isNull(requesterId)
+                Objects.isNull(nickname)
                         ? cb.equal(root.get("status"), PostStatus.PUBLISHED)
                         : null;
     }
 
     /**
-     * User인 경우 본인 게시글만 (Guest는 조건 없음 → 전체 사용자)
+     * 항상 PUBLISHED 상태만
      */
-    private static Specification<Post> ownedByUser(Long requesterId) {
+    private static Specification<Post> onlyPublished() {
+        return (root, query, cb) -> cb.equal(root.get("status"), PostStatus.PUBLISHED);
+    }
+
+    /**
+     * 닉네임 일치하는 사용자의 게시글만 (null이면 조건 없음 → 전체 사용자)
+     */
+    private static Specification<Post> nicknameEquals(String nickname) {
         return (root, query, cb) ->
-                Objects.nonNull(requesterId)
-                        ? cb.equal(root.get("user").get("id"), requesterId)
+                Objects.nonNull(nickname)
+                        ? cb.equal(root.get("user").get("nickname"), nickname)
                         : null;
     }
 }

--- a/src/main/java/com/sealog/backend/domain/feature/post/repository/condition/PostCondition.java
+++ b/src/main/java/com/sealog/backend/domain/feature/post/repository/condition/PostCondition.java
@@ -1,0 +1,76 @@
+package com.sealog.backend.domain.feature.post.repository.condition;
+
+import com.sealog.backend.domain.feature.post.entity.Post;
+import com.sealog.backend.domain.feature.post.enums.PostStatus;
+import lombok.experimental.UtilityClass;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.util.Objects;
+
+/**
+ * Post 검색 조건 Specification 모음
+ *
+ * 사용 목적:
+ * - Guest/User 역할별 동적 조건 조합
+ * - requesterId = null → Guest (PUBLISHED만, 전체 사용자)
+ * - requesterId != null → User (전체 상태, 본인 게시글만)
+ */
+@UtilityClass
+public class PostCondition {
+
+    /**
+     * 게시글 검색 조건 조합
+     * - 삭제되지 않은 게시글 + 키워드 매칭 + 역할별 조건
+     *
+     * @param requesterId 요청자 ID (null = Guest, non-null = User)
+     * @param keyword     검색 키워드
+     * @return 조합된 Specification
+     */
+    public static Specification<Post> search(Long requesterId, String keyword) {
+        return Specification.allOf(
+                notDeleted(),
+                keywordContains(keyword),
+                onlyPublishedIfGuest(requesterId),
+                ownedByUser(requesterId)
+        );
+    }
+
+    // ========== private conditions ========== //
+
+    /**
+     * 소프트 삭제되지 않은 게시글
+     */
+    private static Specification<Post> notDeleted() {
+        return (root, query, cb) -> cb.isNull(root.get("deletedAt"));
+    }
+
+    /**
+     * 제목 또는 요약에 키워드 포함
+     */
+    private static Specification<Post> keywordContains(String keyword) {
+        return (root, query, cb) -> cb.or(
+                cb.like(root.get("title"), "%" + keyword + "%"),
+                cb.like(root.get("excerpt"), "%" + keyword + "%")
+        );
+    }
+
+    /**
+     * Guest인 경우 PUBLISHED 상태만 (User는 조건 없음 → 전체 상태)
+     */
+    private static Specification<Post> onlyPublishedIfGuest(Long requesterId) {
+        return (root, query, cb) ->
+                Objects.isNull(requesterId)
+                        ? cb.equal(root.get("status"), PostStatus.PUBLISHED)
+                        : null;
+    }
+
+    /**
+     * User인 경우 본인 게시글만 (Guest는 조건 없음 → 전체 사용자)
+     */
+    private static Specification<Post> ownedByUser(Long requesterId) {
+        return (root, query, cb) ->
+                Objects.nonNull(requesterId)
+                        ? cb.equal(root.get("user").get("id"), requesterId)
+                        : null;
+    }
+}

--- a/src/main/java/com/sealog/backend/domain/feature/post/service/PostService.java
+++ b/src/main/java/com/sealog/backend/domain/feature/post/service/PostService.java
@@ -48,25 +48,37 @@ public interface PostService {
 
     /**
      * 게시글 검색
-     * - requesterId = null  → Guest: PUBLISHED 상태만, 전체 사용자 대상
-     * - requesterId != null → User:  전체 상태(PUBLISHED+DRAFT), 본인 게시글만
+     * - nickname = null  → Guest: PUBLISHED 상태만, 전체 사용자 대상
+     * - nickname != null → User:  전체 상태(PUBLISHED+DRAFT), 본인 게시글만
      *
-     * @param requesterId 요청자 ID (null = Guest, non-null = User)
-     * @param keyword     검색 키워드
-     * @param pageable    페이지네이션 정보
+     * @param nickname 요청자 닉네임 (null = Guest, non-null = User)
+     * @param keyword  검색 키워드
+     * @param pageable 페이지네이션 정보
      * @return 검색된 게시글 목록
      */
-    Page<PostResponse.PostItems> searchPosts(Long requesterId, String keyword, Pageable pageable);
+    Page<PostResponse.PostItems> searchPosts(String nickname, String keyword, Pageable pageable);
 
     /**
-     * 스택별 공개 게시글 목록 조회
-     * - PUBLISHED 상태만 조회
+     * 특정 사용자의 공개 게시글 검색
+     * - PUBLISHED 상태만, 닉네임 일치하는 사용자의 게시글만
      *
+     * @param nickname 검색 대상 사용자 닉네임
+     * @param keyword  검색 키워드
+     * @param pageable 페이지네이션 정보
+     * @return 검색된 게시글 목록
+     */
+    Page<PostResponse.PostItems> searchPostsByNickname(String nickname, String keyword, Pageable pageable);
+
+    /**
+     * 특정 사용자의 스택별 공개 게시글 목록 조회
+     * - PUBLISHED 상태만, 닉네임 일치하는 사용자의 게시글만
+     *
+     * @param nickname  조회할 사용자 닉네임
      * @param stackName 조회할 스택 이름 (Stack.name, unique)
      * @param pageable  페이지네이션 정보
      * @return 해당 스택이 적용된 게시글 목록
      */
-    Page<PostResponse.PostItems> getPostsByStack(String stackName, Pageable pageable);
+    Page<PostResponse.PostItems> getPostsByStack(String nickname, String stackName, Pageable pageable);
 
     // ========== Create, Update, Delete ========== //
 

--- a/src/main/java/com/sealog/backend/domain/feature/post/service/PostService.java
+++ b/src/main/java/com/sealog/backend/domain/feature/post/service/PostService.java
@@ -8,8 +8,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.util.List;
-
 /**
  * 게시글 서비스 인터페이스
  *
@@ -49,13 +47,26 @@ public interface PostService {
     PostResponse.Detail getDetail(String nickname, String slug);
 
     /**
-     * 게시글 전체 자동완성 검색
-     * - PUBLISHED 상태만 검색
+     * 게시글 검색
+     * - requesterId = null  → Guest: PUBLISHED 상태만, 전체 사용자 대상
+     * - requesterId != null → User:  전체 상태(PUBLISHED+DRAFT), 본인 게시글만
      *
-     * @param keyword 검색 키워드
-     * @return 검색된 게시글 목록 (최대 10개)
+     * @param requesterId 요청자 ID (null = Guest, non-null = User)
+     * @param keyword     검색 키워드
+     * @param pageable    페이지네이션 정보
+     * @return 검색된 게시글 목록
      */
-    List<PostResponse.PostItems> autocomplete(String keyword);
+    Page<PostResponse.PostItems> searchPosts(Long requesterId, String keyword, Pageable pageable);
+
+    /**
+     * 스택별 공개 게시글 목록 조회
+     * - PUBLISHED 상태만 조회
+     *
+     * @param stackName 조회할 스택 이름 (Stack.name, unique)
+     * @param pageable  페이지네이션 정보
+     * @return 해당 스택이 적용된 게시글 목록
+     */
+    Page<PostResponse.PostItems> getPostsByStack(String stackName, Pageable pageable);
 
     // ========== Create, Update, Delete ========== //
 

--- a/src/main/java/com/sealog/backend/domain/feature/post/service/PostServiceImpl.java
+++ b/src/main/java/com/sealog/backend/domain/feature/post/service/PostServiceImpl.java
@@ -6,6 +6,7 @@ import com.sealog.backend.domain.feature.post.dto.PostResponse;
 import com.sealog.backend.domain.feature.post.entity.Post;
 import com.sealog.backend.domain.feature.post.enums.PostStatus;
 import com.sealog.backend.domain.feature.post.repository.PostRepository;
+import com.sealog.backend.domain.feature.post.repository.condition.PostCondition;
 import com.sealog.backend.domain.feature.post.util.PostHtmlParser;
 import com.sealog.backend.domain.feature.post.util.PostHtmlSanitizer;
 import com.sealog.backend.domain.feature.post.util.PostSlugGenerator;
@@ -15,14 +16,15 @@ import com.sealog.backend.infra.storage.service.FileStorageService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 @Slf4j
@@ -54,17 +56,19 @@ public class PostServiceImpl implements PostService {
 
     @Override
     public PostResponse.Detail getDetail(String nickname, String slug) {
-        Post post = postRepository.findPublishedByNicknameAndSlug(nickname, slug)
-                .orElseThrow(() -> CustomException.notFound("게시글을 찾을 수 없습니다"));
 
-        return buildPostDetailResponse(post);
+        return postRepository
+                .findPublishedByNicknameAndSlug(nickname, slug)
+                .map(this::buildPostDetailResponse)
+                .orElseThrow(() -> CustomException.notFound("게시글을 찾을 수 없습니다"));
     }
 
     @Override
-    public List<PostResponse.PostItems> autocomplete(String keyword) {
-        return postRepository.findPublishedByKeyword(keyword, PageRequest.of(0, 10)).stream()
-                .map(this::buildPostItemsResponse)
-                .toList();
+    public Page<PostResponse.PostItems> searchPosts(Long requesterId, String keyword, Pageable pageable) {
+        Specification<Post> spec = PostCondition.search(requesterId, keyword);
+        return postRepository
+                .findAll(spec, pageable)
+                .map(this::buildPostItemsResponse);
     }
 
     @Override
@@ -92,8 +96,16 @@ public class PostServiceImpl implements PostService {
     }
 
     @Override
+    public Page<PostResponse.PostItems> getPostsByStack(String stackName, Pageable pageable) {
+        return postRepository
+                .findPublishedByStackName(stackName, pageable)
+                .map(this::buildPostItemsResponse);
+    }
+
+    @Override
     public Page<PostResponse.PostItems> getDeleted(Long userId, Pageable pageable) {
-        return postRepository.findDeletedPostsByUserId(userId, pageable)
+        return postRepository
+                .findDeletedPostsByUserId(userId, pageable)
                 .map(this::buildPostItemsResponse);
     }
 
@@ -266,6 +278,7 @@ public class PostServiceImpl implements PostService {
         );
 
         String displayContent = PostHtmlParser.injectSrcAttributes(post.getContent(), fileStorageService.getBaseUrl());
+        String archiveSlug = Objects.nonNull(post.getArchive()) ? post.getArchive().getSlug() : null;
 
         return PostResponse.Detail.of(
                 post.getId(),
@@ -278,6 +291,7 @@ public class PostServiceImpl implements PostService {
                 tagNames,
                 stackItems,
                 author,
+                archiveSlug,
                 post.getCreatedAt(),
                 post.getUpdatedAt()
         );

--- a/src/main/java/com/sealog/backend/domain/feature/post/service/PostServiceImpl.java
+++ b/src/main/java/com/sealog/backend/domain/feature/post/service/PostServiceImpl.java
@@ -64,8 +64,8 @@ public class PostServiceImpl implements PostService {
     }
 
     @Override
-    public Page<PostResponse.PostItems> searchPosts(Long requesterId, String keyword, Pageable pageable) {
-        Specification<Post> spec = PostCondition.search(requesterId, keyword);
+    public Page<PostResponse.PostItems> searchPosts(String nickname, String keyword, Pageable pageable) {
+        Specification<Post> spec = PostCondition.search(nickname, keyword);
         return postRepository
                 .findAll(spec, pageable)
                 .map(this::buildPostItemsResponse);
@@ -96,9 +96,17 @@ public class PostServiceImpl implements PostService {
     }
 
     @Override
-    public Page<PostResponse.PostItems> getPostsByStack(String stackName, Pageable pageable) {
+    public Page<PostResponse.PostItems> searchPostsByNickname(String nickname, String keyword, Pageable pageable) {
+        Specification<Post> spec = PostCondition.searchByNickname(nickname, keyword);
         return postRepository
-                .findPublishedByStackName(stackName, pageable)
+                .findAll(spec, pageable)
+                .map(this::buildPostItemsResponse);
+    }
+
+    @Override
+    public Page<PostResponse.PostItems> getPostsByStack(String nickname, String stackName, Pageable pageable) {
+        return postRepository
+                .findPublishedByNicknameAndStackName(nickname, stackName, pageable)
                 .map(this::buildPostItemsResponse);
     }
 
@@ -279,6 +287,7 @@ public class PostServiceImpl implements PostService {
 
         String displayContent = PostHtmlParser.injectSrcAttributes(post.getContent(), fileStorageService.getBaseUrl());
         String archiveSlug = Objects.nonNull(post.getArchive()) ? post.getArchive().getSlug() : null;
+        String archiveName = Objects.nonNull(post.getArchive()) ? post.getArchive().getName() : null;
 
         return PostResponse.Detail.of(
                 post.getId(),
@@ -292,6 +301,7 @@ public class PostServiceImpl implements PostService {
                 stackItems,
                 author,
                 archiveSlug,
+                archiveName,
                 post.getCreatedAt(),
                 post.getUpdatedAt()
         );

--- a/src/test/java/com/sealog/backend/domain/feature/post/persistence/PostStackPersistenceTest.java
+++ b/src/test/java/com/sealog/backend/domain/feature/post/persistence/PostStackPersistenceTest.java
@@ -1,0 +1,99 @@
+package com.sealog.backend.domain.feature.post.persistence;
+
+import com.sealog.backend.domain.feature.post.entity.Post;
+import com.sealog.backend.domain.feature.post.entity.PostStack;
+import com.sealog.backend.domain.feature.post.enums.PostStatus;
+import com.sealog.backend.domain.feature.post.repository.PostRepository;
+import com.sealog.backend.domain.feature.post.repository.PostStackRepository;
+import com.sealog.backend.domain.feature.stack.entity.Stack;
+import com.sealog.backend.domain.feature.stack.enums.StackGroup;
+import com.sealog.backend.domain.feature.user.entity.User;
+import com.sealog.backend.domain.feature.user.enums.UserRole;
+import com.sealog.backend.support.base.TestPersistenceBase;
+import com.sealog.backend.support.component.TestDataFactory;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * PostStack 쿼리 성능 측정 테스트
+ * - 성공/실패 검증이 아닌 실행 시간 측정 목적
+ * - ExecutionTimeExtension이 각 테스트 메서드 수행 시간을 자동 로깅
+ * - @BeforeAll로 초기 데이터를 클래스 전체에서 1회만 생성, @AfterAll에서 정리
+ */
+@DisplayName("PostStack 쿼리 성능 측정")
+class PostStackPersistenceTest extends TestPersistenceBase {
+
+    @Autowired TestDataFactory testDataFactory;
+    @Autowired PostStackRepository postStackRepository;
+    @Autowired PostRepository postRepository;
+
+    private User testUser;
+    private List<Stack> stacks;
+
+    @BeforeAll
+    void setUpAll() {
+
+        // 1. 사용자 1명 생성
+        testUser = testDataFactory.createUser(UserRole.USER);
+
+        // 2. 스택 5개 생성
+        stacks = List.of(
+                testDataFactory.createStack(StackGroup.LANGUAGE),
+                testDataFactory.createStack(StackGroup.LANGUAGE),
+                testDataFactory.createStack(StackGroup.FRAMEWORK),
+                testDataFactory.createStack(StackGroup.FRAMEWORK),
+                testDataFactory.createStack(StackGroup.TOOL)
+        );
+
+        // 3. 공개 게시글 10만개 생성
+        testDataFactory.createTestPosts(100, PostStatus.PUBLISHED, testUser);
+
+        // 4. PostStack 매핑 생성 (게시글당 스택 1개, 스택별 약 2만개 배분)
+        List<Post> posts = postRepository.findAll();
+        List<PostStack> mappings = new ArrayList<>();
+
+        for (int i = 0; i < posts.size(); i++) {
+            mappings.add(PostStack.builder()
+                    .post(posts.get(i))
+                    .stack(stacks.get(i % stacks.size()))
+                    .sortOrder(1)
+                    .build());
+        }
+
+        postStackRepository.saveAll(mappings);
+    }
+
+    @Test
+    @Order(0)
+    void warmUp() {
+        // 아무것도 안 함, JVM 웜업용
+    }
+
+    // =====================================================================
+    // 성능 측정
+    // =====================================================================
+
+    @Test
+    @DisplayName("findStacksWithPublicPostCount - 전체 스택별 게시글 수 집계 (페이징 없음)")
+    void findStacksWithPublicPostCount() {
+        List<Object[]> result = postStackRepository.findStacksWithPublicPostCount();
+        System.out.println("[결과] 집계된 스택 수: " + result.size());
+    }
+
+    @Test
+    @DisplayName("findStacksWithPublicPostCountByUser - 특정 사용자 스택별 게시글 수 집계 (nickname 조인)")
+    void findStacksWithPublicPostCountByUser() {
+        List<Object[]> result = postStackRepository.findStacksWithPublicPostCountByUser(testUser.getNickname());
+        System.out.println("[결과] 집계된 스택 수: " + result.size());
+    }
+
+    @Test
+    @DisplayName("findPopularStacks - 인기 스택 상위 3개 조회 (LIMIT 적용)")
+    void findPopularStacks() {
+        List<Object[]> result = postStackRepository.findPopularStacks(3);
+        System.out.println("[결과] 조회된 인기 스택 수: " + result.size());
+    }
+}

--- a/src/test/java/com/sealog/backend/support/base/TestPersistenceBase.java
+++ b/src/test/java/com/sealog/backend/support/base/TestPersistenceBase.java
@@ -1,23 +1,55 @@
 package com.sealog.backend.support.base;
 
-import com.sealog.backend.support.extension.ExecutionTimeExtension;
 import com.sealog.backend.support.component.TestDataFactory;
+import com.sealog.backend.support.constant.TestContainer;
 import com.sealog.backend.support.constant.TestMode;
+import com.sealog.backend.support.constant.TestSql;
+import com.sealog.backend.support.extension.ExecutionTimeExtension;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
 
 /**
- * 일반 테스트의 공통 기능을 관리하는 클래스
+ * 영속성 테스트 공통 기반 클래스
+ *
+ * 특징:
+ * - @DataJpaTest: JPA 레이어만 로드 (경량 컨텍스트)
+ * - @TestInstance(PER_CLASS): @BeforeAll / @AfterAll non-static 허용, @Autowired 필드 사용 가능
+ * - ExecutionTimeExtension: 각 테스트 메서드 수행 시간 자동 로깅
+ * - @AfterAll clearDatabase: 클래스 종료 후 테이블 전체 TRUNCATE
  */
-
+@Slf4j
 @Tag(TestMode.PERSISTENCE)
 @Import(TestDataFactory.class)
 @ExtendWith(ExecutionTimeExtension.class)
 @ActiveProfiles("test")
 @DataJpaTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 public abstract class TestPersistenceBase extends TestContainerBase {
 
+    // 사용 의존성
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    /**
+     * 클래스 종료 후 테이블 전체 초기화
+     * - @BeforeAll로 커밋된 데이터 정리
+     * - @BeforeEach(롤백) 방식 사용 시에도 no-op으로 안전
+     */
+    @AfterAll
+    void clearDatabase() {
+        jdbcTemplate.execute(TestSql.FOREIGN_KEY_CHECKS_INACTIVATION);
+        jdbcTemplate
+                .queryForList(TestSql.SELECT_TABLE_NAMES, String.class, TestContainer.DEFAULT_DATABASE_NAME)
+                .forEach(tableName -> jdbcTemplate.execute(TestSql.TRUNCATE_TABLE + tableName));
+        jdbcTemplate.execute(TestSql.FOREIGN_KEY_CHECKS_ACTIVATION);
+        log.warn("영속성 테스트 데이터 삭제 성공");
+    }
 }


### PR DESCRIPTION
[feat] PostStackPersistenceTest 추가
* PostStackRepository 3개 쿼리(findStacksWithPublicPostCount, findStacksWithPublicPostCountByUser, findPopularStacks) 수행 시간 측정
* ExecutionTimeExtension으로 각 테스트 메서드 실행 시간 자동 로깅

[refactor] TestPersistenceBase 개선
* @TestInstance(PER_CLASS) 추가 — 서브클래스에서 non-static @BeforeAll 허용
* @Autowired JdbcTemplate + @AfterAll clearDatabase() 추가 — 영속성 테스트 클래스 종료 후 전체 테이블 TRUNCATE 자동 수행

[feat] User 게시글 검색 엔드포인트 추가 (GET /api/user/posts/search)
* PostUserController, PostUserControllerDocs에 searchPosts 추가
* 로그인 사용자: 본인 게시글 전체 상태(PUBLISHED+DRAFT) 검색

[refactor] autocomplete → searchPosts 전환 (Guest)
* GET /api/guest/posts/autocomplete → GET /api/guest/posts/search
* 반환 타입 List → Page<PostItems> (페이징 지원)
* PostGuestController, PostGuestControllerDocs 업데이트

[feat] PostCondition Specification 클래스 신규 작성
* repository/condition/PostCondition.java 생성
* Specification.allOf() 기반 동적 조건 조합 (Spring Data JPA 3.5+ 최신 API)
* requesterId null → Guest(PUBLISHED만), non-null → User(전체 상태, 본인만)

[refactor] PostService.searchPosts() Guest/User 단일 메서드로 통합
* Long requesterId (nullable) 파라미터로 역할 구분
* PostRepository.findPublishedByKeyword() 제거 → findAll(Specification, Pageable) 사용

[feat] 스택별 공개 게시글 목록 조회 (GET /api/guest/posts?stackName=)
* PostRepository: findPublishedByStackName() — EXISTS 서브쿼리 JPQL 추가
* PostService: getPostsByStack(String stackName, Pageable) 추가
* PostServiceImpl: getPostsByStack() 구현
* PostGuestController: @GetMapping(value="/posts", params="stackName") 추가
* PostGuestControllerDocs: Swagger 문서 추가

[feat] PostResponse.Detail에 archiveSlug 및 archiveName 필드 추가
* PostResponse.Detail.of()에 archiveSlug 파라미터 추가 (null 허용)
* PostServiceImpl.buildPostDetailResponse()에서 archive null 안전 추출
* PostRepository.findPublishedByNicknameAndSlug(): LEFT JOIN FETCH p.archive 추가

[feat] 스택별 유저 공개 게시글 조회 추가
* GET /api/guest/{nickname}/posts?stackName=xxx
* findPublishedByNicknameAndStackName() — EXISTS 서브쿼리로 페이징 안전성 확보

[feat] 유저별 공개 게시글 검색 추가
* GET /api/guest/{nickname}/posts/search?keyword=xxx
* searchByNickname(nickname, keyword) — 항상 PUBLISHED 상태만 반환

[refactor] searchPosts 파라미터 Long requesterId → String nickname 변경
* PostCondition.search() 조건 재사용 통일
* UserController: userDetails.getUser().getNickname() 전달