### PR TITLE
[Archive] 아카이브 및 통합 테스트 로직 일부 수정

### DIFF
--- a/src/main/java/com/sealog/backend/domain/feature/archive/controller/ArchiveGuestController.java
+++ b/src/main/java/com/sealog/backend/domain/feature/archive/controller/ArchiveGuestController.java
@@ -19,7 +19,6 @@ import org.springframework.web.bind.annotation.RestController;
  * 아카이브 공개 컨트롤러 (인증 불필요)
  *
  * 역할:
- * - 공개 아카이브 목록 조회 (닉네임 기준)
  * - 아카이브에 속한 공개 게시글 목록 조회
  */
 @RestController
@@ -32,30 +31,17 @@ public class ArchiveGuestController implements ArchiveGuestControllerDocs {
     // ========== 조회 ========== //
 
     /**
-     * 사용자의 공개 아카이브 목록 조회
-     * GET /api/guest/archive/{nickname}
-     */
-    @Override
-    @GetMapping("/{nickname}")
-    public ResponseEntity<CustomResponse<PageResponse<ArchiveResponse.ArchiveItems>>> getPagedItemsByNicknameForGuest(
-            @PathVariable String nickname,
-            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
-    ) {
-        Page<ArchiveResponse.ArchiveItems> result = archiveService.getPagedItemsByNicknameForGuest(nickname, pageable);
-        return ResponseEntity.ok(CustomResponse.success(PageResponse.from(result)));
-    }
-
-    /**
      * 아카이브에 속한 공개 게시글 목록 조회
-     * GET /api/guest/archive/{archiveId}/posts
+     * GET /api/guest/archive/{nickname}/{slug}/posts
      */
     @Override
-    @GetMapping("/{archiveId}/posts")
-    public ResponseEntity<CustomResponse<PageResponse<ArchiveResponse.PostItems>>> getPagedPostItemsByArchiveIdForGuest(
-            @PathVariable Long archiveId,
+    @GetMapping("/{nickname}/{slug}/posts")
+    public ResponseEntity<CustomResponse<PageResponse<ArchiveResponse.PostItems>>> getPagedPostItems(
+            @PathVariable String nickname,
+            @PathVariable String slug,
             @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
     ) {
-        Page<ArchiveResponse.PostItems> result = archiveService.getPagedPostItemsByArchiveIdForGuest(archiveId, pageable);
+        Page<ArchiveResponse.PostItems> result = archiveService.getPagedPostItems(null, nickname, slug, pageable);
         return ResponseEntity.ok(CustomResponse.success(PageResponse.from(result)));
     }
 }

--- a/src/main/java/com/sealog/backend/domain/feature/archive/controller/ArchiveGuestControllerDocs.java
+++ b/src/main/java/com/sealog/backend/domain/feature/archive/controller/ArchiveGuestControllerDocs.java
@@ -16,24 +16,11 @@ import org.springframework.http.ResponseEntity;
  * Archive 공개 API 문서 인터페이스 (Swagger 전용, 인증 불필요)
  *
  * 역할:
- * - 공개 아카이브 목록 조회 (닉네임 기준)
  * - 아카이브에 속한 공개 게시글 목록 조회
  */
 @Tag(name = "Archive", description = "아카이브(모음집) 공개 API (인증 불필요)")
 @SecurityRequirements()
 public interface ArchiveGuestControllerDocs {
-
-    @Operation(
-            summary = "사용자의 공개 아카이브 목록 조회",
-            description = "닉네임 기준으로 공개(isPublic=true) 아카이브 목록을 페이징 조회합니다."
-    )
-    @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "조회 성공")
-    })
-    ResponseEntity<CustomResponse<PageResponse<ArchiveResponse.ArchiveItems>>> getPagedItemsByNicknameForGuest(
-            @Parameter(description = "사용자 닉네임", example = "테스터") String nickname,
-            Pageable pageable
-    );
 
     @Operation(
             summary = "아카이브에 속한 공개 게시글 목록 조회",
@@ -42,8 +29,9 @@ public interface ArchiveGuestControllerDocs {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공")
     })
-    ResponseEntity<CustomResponse<PageResponse<ArchiveResponse.PostItems>>> getPagedPostItemsByArchiveIdForGuest(
-            @Parameter(description = "아카이브 ID", example = "1") Long archiveId,
+    ResponseEntity<CustomResponse<PageResponse<ArchiveResponse.PostItems>>> getPagedPostItems(
+            @Parameter(description = "아카이브 소유자 닉네임", example = "테스터") String nickname,
+            @Parameter(description = "아카이브 slug", example = "spring-boot-study") String slug,
             Pageable pageable
     );
 }

--- a/src/main/java/com/sealog/backend/domain/feature/archive/controller/ArchiveUserController.java
+++ b/src/main/java/com/sealog/backend/domain/feature/archive/controller/ArchiveUserController.java
@@ -51,18 +51,17 @@ public class ArchiveUserController implements ArchiveUserControllerDocs {
 
     /**
      * 내 아카이브 게시글 목록 조회
-     * GET /api/user/archive/{nickname}/{slug}/posts
+     * GET /api/user/archive/{slug}/posts
      */
     @Override
-    @GetMapping("/{nickname}/{slug}/posts")
+    @GetMapping("/{slug}/posts")
     public ResponseEntity<CustomResponse<PageResponse<ArchiveResponse.PostItems>>> getPagedPostItems(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @PathVariable String nickname,
             @PathVariable String slug,
             @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
     ) {
         Page<ArchiveResponse.PostItems> result = archiveService.getPagedPostItems(
-                userDetails.getUserId(), nickname, slug, pageable
+                userDetails.getUserId(), userDetails.getUser().getNickname(), slug, pageable
         );
         return ResponseEntity.ok(CustomResponse.success(PageResponse.from(result)));
     }

--- a/src/main/java/com/sealog/backend/domain/feature/archive/controller/ArchiveUserController.java
+++ b/src/main/java/com/sealog/backend/domain/feature/archive/controller/ArchiveUserController.java
@@ -41,27 +41,28 @@ public class ArchiveUserController implements ArchiveUserControllerDocs {
      */
     @Override
     @GetMapping
-    public ResponseEntity<CustomResponse<PageResponse<ArchiveResponse.ArchiveItems>>> getPagedItemsForUser(
+    public ResponseEntity<CustomResponse<PageResponse<ArchiveResponse.ArchiveItems>>> getPagedItems(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
     ) {
-        Page<ArchiveResponse.ArchiveItems> result = archiveService.getPagedItemsForUser(userDetails.getUserId(), pageable);
+        Page<ArchiveResponse.ArchiveItems> result = archiveService.getPagedItems(userDetails.getUserId(), pageable);
         return ResponseEntity.ok(CustomResponse.success(PageResponse.from(result)));
     }
 
     /**
      * 내 아카이브 게시글 목록 조회
-     * GET /api/user/archive/{archiveId}/posts
+     * GET /api/user/archive/{nickname}/{slug}/posts
      */
     @Override
-    @GetMapping("/{archiveId}/posts")
-    public ResponseEntity<CustomResponse<PageResponse<ArchiveResponse.PostItems>>> getPagedPostItemsByUserIdAndArchiveIdForUser(
+    @GetMapping("/{nickname}/{slug}/posts")
+    public ResponseEntity<CustomResponse<PageResponse<ArchiveResponse.PostItems>>> getPagedPostItems(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @PathVariable Long archiveId,
+            @PathVariable String nickname,
+            @PathVariable String slug,
             @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
     ) {
-        Page<ArchiveResponse.PostItems> result = archiveService.getPagedPostItemsByUserIdAndArchiveIdForUser(
-                userDetails.getUserId(), archiveId, pageable
+        Page<ArchiveResponse.PostItems> result = archiveService.getPagedPostItems(
+                userDetails.getUserId(), nickname, slug, pageable
         );
         return ResponseEntity.ok(CustomResponse.success(PageResponse.from(result)));
     }

--- a/src/main/java/com/sealog/backend/domain/feature/archive/controller/ArchiveUserController.java
+++ b/src/main/java/com/sealog/backend/domain/feature/archive/controller/ArchiveUserController.java
@@ -149,16 +149,17 @@ public class ArchiveUserController implements ArchiveUserControllerDocs {
 
     /**
      * 게시글 아카이브 배정
-     * PATCH /api/user/archive/{archiveId}/post/{postId}
+     * PATCH /api/user/archive/{nickname}/{slug}/post/{postId}
      */
     @Override
-    @PatchMapping("/{archiveId}/post/{postId}")
+    @PatchMapping("/{nickname}/{slug}/post/{postId}")
     public ResponseEntity<CustomResponse<Void>> changePostArchive(
             @AuthenticationPrincipal CustomUserDetails userDetails,
-            @PathVariable Long archiveId,
+            @PathVariable String nickname,
+            @PathVariable String slug,
             @PathVariable Long postId
     ) {
-        archiveService.changePostArchive(userDetails.getUserId(), archiveId, postId);
+        archiveService.changePostArchive(userDetails.getUserId(), postId, nickname, slug);
         return ResponseEntity.ok(CustomResponse.success(null, "게시글이 아카이브에 배정되었습니다"));
     }
 

--- a/src/main/java/com/sealog/backend/domain/feature/archive/controller/ArchiveUserControllerDocs.java
+++ b/src/main/java/com/sealog/backend/domain/feature/archive/controller/ArchiveUserControllerDocs.java
@@ -38,7 +38,7 @@ public interface ArchiveUserControllerDocs {
             @ApiResponse(responseCode = "401", description = "인증 실패",
                     content = @Content(schema = @Schema(hidden = true)))
     })
-    ResponseEntity<CustomResponse<PageResponse<ArchiveResponse.ArchiveItems>>> getPagedItemsForUser(
+    ResponseEntity<CustomResponse<PageResponse<ArchiveResponse.ArchiveItems>>> getPagedItems(
             @Parameter(hidden = true) CustomUserDetails userDetails,
             Pageable pageable
     );
@@ -50,11 +50,14 @@ public interface ArchiveUserControllerDocs {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
             @ApiResponse(responseCode = "401", description = "인증 실패",
+                    content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "403", description = "권한 없음 (소유자 아님)",
                     content = @Content(schema = @Schema(hidden = true)))
     })
-    ResponseEntity<CustomResponse<PageResponse<ArchiveResponse.PostItems>>> getPagedPostItemsByUserIdAndArchiveIdForUser(
+    ResponseEntity<CustomResponse<PageResponse<ArchiveResponse.PostItems>>> getPagedPostItems(
             @Parameter(hidden = true) CustomUserDetails userDetails,
-            @Parameter(description = "아카이브 ID", example = "1") Long archiveId,
+            @Parameter(description = "아카이브 소유자 닉네임", example = "테스터") String nickname,
+            @Parameter(description = "아카이브 slug", example = "spring-boot-study") String slug,
             Pageable pageable
     );
 

--- a/src/main/java/com/sealog/backend/domain/feature/archive/controller/ArchiveUserControllerDocs.java
+++ b/src/main/java/com/sealog/backend/domain/feature/archive/controller/ArchiveUserControllerDocs.java
@@ -158,7 +158,8 @@ public interface ArchiveUserControllerDocs {
     })
     ResponseEntity<CustomResponse<Void>> changePostArchive(
             @Parameter(hidden = true) CustomUserDetails userDetails,
-            @Parameter(description = "배정할 아카이브 ID", example = "1") Long archiveId,
+            @Parameter(description = "소유자 닉네임", example = "테스터") String nickname,
+            @Parameter(description = "아카이브 slug", example = "spring-boot-study") String slug,
             @Parameter(description = "배정할 게시글 ID", example = "1") Long postId
     );
 

--- a/src/main/java/com/sealog/backend/domain/feature/archive/controller/ArchiveUserControllerDocs.java
+++ b/src/main/java/com/sealog/backend/domain/feature/archive/controller/ArchiveUserControllerDocs.java
@@ -56,7 +56,6 @@ public interface ArchiveUserControllerDocs {
     })
     ResponseEntity<CustomResponse<PageResponse<ArchiveResponse.PostItems>>> getPagedPostItems(
             @Parameter(hidden = true) CustomUserDetails userDetails,
-            @Parameter(description = "아카이브 소유자 닉네임", example = "테스터") String nickname,
             @Parameter(description = "아카이브 slug", example = "spring-boot-study") String slug,
             Pageable pageable
     );

--- a/src/main/java/com/sealog/backend/domain/feature/archive/service/ArchiveService.java
+++ b/src/main/java/com/sealog/backend/domain/feature/archive/service/ArchiveService.java
@@ -14,24 +14,18 @@ public interface ArchiveService {
     // ========== Guest (공개) ========== //
 
     /**
-     * 닉네임 기준 공개 아카이브 목록 페이징 조회
-     * - isPublic = true인 아카이브만 반환
-     *
-     * @param nickname 소유자 닉네임
-     * @param pageable 페이징 정보
-     * @return 공개 아카이브 목록
-     */
-    Page<ArchiveResponse.ArchiveItems> getPagedItemsByNicknameForGuest(String nickname, Pageable pageable);
-
-    /**
      * 아카이브에 속한 게시글 목록 페이징 조회
-     * - PUBLISHED 상태 게시글만 반환
+     * - requesterId null → PUBLISHED 상태만 반환 (Guest)
+     * - requesterId non-null → 소유자 검증 후 전체 상태 반환 (User)
      *
-     * @param archiveId 아카이브 ID
-     * @param pageable  페이징 정보
-     * @return 공개 게시글 목록
+     * @param requesterId 요청 사용자 ID (null = 비인증 Guest)
+     * @param nickname    아카이브 소유자 닉네임
+     * @param slug        아카이브 slug
+     * @param pageable    페이징 정보
+     * @return 게시글 목록
+     * @throws CustomException 아카이브 없음, 권한 없음 (User 요청 시)
      */
-    Page<ArchiveResponse.PostItems> getPagedPostItemsByArchiveIdForGuest(Long archiveId, Pageable pageable);
+    Page<ArchiveResponse.PostItems> getPagedPostItems(Long requesterId, String nickname, String slug, Pageable pageable);
 
     // ========== User (인증) ========== //
 
@@ -43,18 +37,7 @@ public interface ArchiveService {
      * @param pageable 페이징 정보
      * @return 전체 아카이브 목록 (공개·비공개 포함)
      */
-    Page<ArchiveResponse.ArchiveItems> getPagedItemsForUser(Long userId, Pageable pageable);
-
-    /**
-     * 사용자 본인의 아카이브에 속한 게시글 목록 페이징 조회
-     * - PUBLISHED/DRAFT 상태 무관하게 모두 반환
-     *
-     * @param userId    조회 대상 사용자 ID
-     * @param archiveId 아카이브 ID
-     * @param pageable  페이징 정보
-     * @return 전체 게시글 목록 (게시/임시저장 포함)
-     */
-    Page<ArchiveResponse.PostItems> getPagedPostItemsByUserIdAndArchiveIdForUser(Long userId, Long archiveId, Pageable pageable);
+    Page<ArchiveResponse.ArchiveItems> getPagedItems(Long userId, Pageable pageable);
 
     /**
      * 아카이브 생성

--- a/src/main/java/com/sealog/backend/domain/feature/archive/service/ArchiveService.java
+++ b/src/main/java/com/sealog/backend/domain/feature/archive/service/ArchiveService.java
@@ -112,12 +112,13 @@ public interface ArchiveService {
      * 게시글의 소속 아카이브 변경 (배정/재배정)
      * - 이미 다른 아카이브에 속해 있는 경우 교체됨
      *
-     * @param userId    요청 사용자 ID
-     * @param archiveId 지정할 아카이브 ID
-     * @param postId    변경 대상 게시글 ID
+     * @param userId   요청 사용자 ID
+     * @param postId   변경 대상 게시글 ID
+     * @param nickname 소유자 닉네임
+     * @param slug     삭제할 아카이브 slug
      * @throws CustomException 게시글 없음, 아카이브 없음, 권한 없음
      */
-    void changePostArchive(Long userId, Long archiveId, Long postId);
+    void changePostArchive(Long userId, Long postId, String nickname, String slug);
 
     /**
      * 게시글의 아카이브 배정 해제

--- a/src/main/java/com/sealog/backend/domain/feature/archive/service/ArchiveServiceImpl.java
+++ b/src/main/java/com/sealog/backend/domain/feature/archive/service/ArchiveServiceImpl.java
@@ -35,35 +35,31 @@ public class ArchiveServiceImpl implements ArchiveService {
     private final UserRepository userRepository;
 
     @Override
-    public Page<ArchiveResponse.ArchiveItems> getPagedItemsByNicknameForGuest(String nickname, Pageable pageable) {
+    public Page<ArchiveResponse.PostItems> getPagedPostItems(Long requesterId, String nickname, String slug, Pageable pageable) {
 
-        return archiveRepository
-                .findByUserNicknameAndIsPublic(nickname, true, pageable)
-                .map(this::toItems);
-    }
+        // 1. 아카이브 조회
+        Archive archive = findArchiveByNicknameAndSlug(nickname, slug);
 
-    @Override
-    public Page<ArchiveResponse.PostItems> getPagedPostItemsByArchiveIdForGuest(Long archiveId, Pageable pageable) {
+        // 2. User: 소유자 검증 후 전체 상태 반환
+        if (Objects.nonNull(requesterId)) {
+            verifyOwner(archive, requesterId);
+            return postRepository
+                    .findByUserIdAndArchiveId(requesterId, archive.getId(), pageable)
+                    .map(this::toPostItems);
+        }
 
+        // 3. Guest: PUBLISHED만 반환
         return postRepository
-                .findByArchiveIdAndStatus(archiveId, PostStatus.PUBLISHED, pageable)
+                .findByArchiveIdAndStatus(archive.getId(), PostStatus.PUBLISHED, pageable)
                 .map(this::toPostItems);
     }
 
     @Override
-    public Page<ArchiveResponse.ArchiveItems> getPagedItemsForUser(Long userId, Pageable pageable) {
+    public Page<ArchiveResponse.ArchiveItems> getPagedItems(Long userId, Pageable pageable) {
 
         return archiveRepository
                 .findByUserId(userId, pageable)
                 .map(this::toItems);
-    }
-
-    @Override
-    public Page<ArchiveResponse.PostItems> getPagedPostItemsByUserIdAndArchiveIdForUser(Long userId, Long archiveId, Pageable pageable) {
-
-        return postRepository
-                .findByUserIdAndArchiveId(userId, archiveId, pageable)
-                .map(this::toPostItems);
     }
 
     @Transactional

--- a/src/main/java/com/sealog/backend/domain/feature/archive/service/ArchiveServiceImpl.java
+++ b/src/main/java/com/sealog/backend/domain/feature/archive/service/ArchiveServiceImpl.java
@@ -161,14 +161,14 @@ public class ArchiveServiceImpl implements ArchiveService {
 
     @Transactional
     @Override
-    public void changePostArchive(Long userId, Long archiveId, Long postId) {
+    public void changePostArchive(Long userId, Long postId, String nickname, String slug) {
 
         // 1. Post 조회 및 검증
         Post post = findPostById(postId);
         verifyOwner(post, userId);
 
         // 2. Archive 조회 및 검증
-        Archive archive = findArchiveById(archiveId);
+        Archive archive = findArchiveByNicknameAndSlug(nickname, slug);
         verifyOwner(archive, userId);
 
         // 3. 변경
@@ -210,12 +210,6 @@ public class ArchiveServiceImpl implements ArchiveService {
                 .orElseThrow(() -> CustomException.notFound("존재하지 않거나 이미 삭제된 아카이브입니다."));
     }
 
-    private Archive findArchiveById(Long id) {
-
-        return archiveRepository
-                .findById(id)
-                .orElseThrow(() -> CustomException.notFound("존재하지 않거나 이미 삭제된 아카이브입니다."));
-    }
 
     private Post findPostById(Long postId) {
 

--- a/src/test/java/com/sealog/backend/domain/feature/archive/integration/ArchiveIntegrationTest.java
+++ b/src/test/java/com/sealog/backend/domain/feature/archive/integration/ArchiveIntegrationTest.java
@@ -70,34 +70,17 @@ class ArchiveIntegrationTest extends TestIntegrationBase {
     }
 
     // =====================================================================
-    // 공개 아카이브 목록 조회 (Guest)
-    // =====================================================================
-    @Nested
-    @DisplayName("공개 아카이브 목록 조회 (Guest GET /{nickname})")
-    class 공개_아카이브_목록_조회 {
-
-        @Test
-        @DisplayName("성공 - 공개 아카이브만 반환 → 200, 비공개 미포함")
-        void 성공() throws Exception {
-            mockMvc.perform(get("/api/guest/archive/{nickname}", testUser.getNickname()))
-                    .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.success").value(true))
-                    .andExpect(jsonPath("$.data.totalElements").value(1))
-                    .andExpect(jsonPath("$.data.content[0].slug").value(testArchive.getSlug()));
-        }
-    }
-
-    // =====================================================================
     // 아카이브 내 공개 게시글 조회 (Guest)
     // =====================================================================
     @Nested
-    @DisplayName("아카이브 내 공개 게시글 조회 (Guest GET /{archiveId}/posts)")
+    @DisplayName("아카이브 내 공개 게시글 조회 (Guest GET /{nickname}/{slug}/posts)")
     class 아카이브_내_공개_게시글_조회 {
 
         @Test
         @DisplayName("성공 - PUBLISHED 게시글 반환 → 200")
         void 성공() throws Exception {
-            mockMvc.perform(get("/api/guest/archive/{archiveId}/posts", testArchive.getId()))
+            mockMvc.perform(get("/api/guest/archive/{nickname}/{slug}/posts",
+                            testUser.getNickname(), testArchive.getSlug()))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))
                     .andExpect(jsonPath("$.data.totalElements").value(1))
@@ -135,13 +118,14 @@ class ArchiveIntegrationTest extends TestIntegrationBase {
     // 내 아카이브 게시글 목록 조회 (User)
     // =====================================================================
     @Nested
-    @DisplayName("내 아카이브 게시글 목록 조회 (User GET /{archiveId}/posts)")
+    @DisplayName("내 아카이브 게시글 목록 조회 (User GET /{nickname}/{slug}/posts)")
     class 내_아카이브_게시글_목록_조회 {
 
         @Test
         @DisplayName("성공 → 200")
         void 성공() throws Exception {
-            mockMvc.perform(get("/api/user/archive/{archiveId}/posts", testArchive.getId())
+            mockMvc.perform(get("/api/user/archive/{nickname}/{slug}/posts",
+                            testUser.getNickname(), testArchive.getSlug())
                             .with(user(myDetails)))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))
@@ -149,9 +133,19 @@ class ArchiveIntegrationTest extends TestIntegrationBase {
         }
 
         @Test
+        @DisplayName("실패 - 타인 아카이브 접근 → 403")
+        void 권한_없음() throws Exception {
+            mockMvc.perform(get("/api/user/archive/{nickname}/{slug}/posts",
+                            testUser.getNickname(), testArchive.getSlug())
+                            .with(user(otherDetails)))
+                    .andExpect(status().isForbidden());
+        }
+
+        @Test
         @DisplayName("실패 - 미인증 → 401")
         void 미인증() throws Exception {
-            mockMvc.perform(get("/api/user/archive/{archiveId}/posts", testArchive.getId())
+            mockMvc.perform(get("/api/user/archive/{nickname}/{slug}/posts",
+                            testUser.getNickname(), testArchive.getSlug())
                             .with(anonymous()))
                     .andExpect(status().isUnauthorized());
         }

--- a/src/test/java/com/sealog/backend/domain/feature/archive/integration/ArchiveIntegrationTest.java
+++ b/src/test/java/com/sealog/backend/domain/feature/archive/integration/ArchiveIntegrationTest.java
@@ -118,14 +118,13 @@ class ArchiveIntegrationTest extends TestIntegrationBase {
     // 내 아카이브 게시글 목록 조회 (User)
     // =====================================================================
     @Nested
-    @DisplayName("내 아카이브 게시글 목록 조회 (User GET /{nickname}/{slug}/posts)")
+    @DisplayName("내 아카이브 게시글 목록 조회 (User GET /{slug}/posts)")
     class 내_아카이브_게시글_목록_조회 {
 
         @Test
         @DisplayName("성공 → 200")
         void 성공() throws Exception {
-            mockMvc.perform(get("/api/user/archive/{nickname}/{slug}/posts",
-                            testUser.getNickname(), testArchive.getSlug())
+            mockMvc.perform(get("/api/user/archive/{slug}/posts", testArchive.getSlug())
                             .with(user(myDetails)))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true))
@@ -135,8 +134,7 @@ class ArchiveIntegrationTest extends TestIntegrationBase {
         @Test
         @DisplayName("실패 - 타인 아카이브 접근 → 403")
         void 권한_없음() throws Exception {
-            mockMvc.perform(get("/api/user/archive/{nickname}/{slug}/posts",
-                            testUser.getNickname(), testArchive.getSlug())
+            mockMvc.perform(get("/api/user/archive/{slug}/posts", testArchive.getSlug())
                             .with(user(otherDetails)))
                     .andExpect(status().isForbidden());
         }
@@ -144,8 +142,7 @@ class ArchiveIntegrationTest extends TestIntegrationBase {
         @Test
         @DisplayName("실패 - 미인증 → 401")
         void 미인증() throws Exception {
-            mockMvc.perform(get("/api/user/archive/{nickname}/{slug}/posts",
-                            testUser.getNickname(), testArchive.getSlug())
+            mockMvc.perform(get("/api/user/archive/{slug}/posts", testArchive.getSlug())
                             .with(anonymous()))
                     .andExpect(status().isUnauthorized());
         }

--- a/src/test/java/com/sealog/backend/domain/feature/archive/integration/ArchiveIntegrationTest.java
+++ b/src/test/java/com/sealog/backend/domain/feature/archive/integration/ArchiveIntegrationTest.java
@@ -358,14 +358,14 @@ class ArchiveIntegrationTest extends TestIntegrationBase {
     // 게시글 아카이브 배정
     // =====================================================================
     @Nested
-    @DisplayName("게시글 아카이브 배정 (PATCH /{archiveId}/post/{postId})")
+    @DisplayName("게시글 아카이브 배정 (PATCH /{nickname}/{slug}/post/{postId})")
     class 게시글_아카이브_배정 {
 
         @Test
         @DisplayName("성공 → 200")
         void 성공() throws Exception {
-            mockMvc.perform(patch("/api/user/archive/{archiveId}/post/{postId}",
-                            testArchive.getId(), unassignedPost.getId())
+            mockMvc.perform(patch("/api/user/archive/{nickname}/{slug}/post/{postId}",
+                            testUser.getNickname(), testArchive.getSlug(), unassignedPost.getId())
                             .with(user(myDetails)))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.success").value(true));
@@ -374,8 +374,8 @@ class ArchiveIntegrationTest extends TestIntegrationBase {
         @Test
         @DisplayName("실패 - 타인 게시글 배정 시도 → 403")
         void 타인_게시글() throws Exception {
-            mockMvc.perform(patch("/api/user/archive/{archiveId}/post/{postId}",
-                            testArchive.getId(), otherPost.getId())
+            mockMvc.perform(patch("/api/user/archive/{nickname}/{slug}/post/{postId}",
+                            testUser.getNickname(), testArchive.getSlug(), otherPost.getId())
                             .with(user(myDetails)))
                     .andExpect(status().isForbidden());
         }
@@ -383,8 +383,8 @@ class ArchiveIntegrationTest extends TestIntegrationBase {
         @Test
         @DisplayName("실패 - 타인 아카이브에 배정 시도 → 403")
         void 타인_아카이브() throws Exception {
-            mockMvc.perform(patch("/api/user/archive/{archiveId}/post/{postId}",
-                            otherArchive.getId(), unassignedPost.getId())
+            mockMvc.perform(patch("/api/user/archive/{nickname}/{slug}/post/{postId}",
+                            otherUser.getNickname(), otherArchive.getSlug(), unassignedPost.getId())
                             .with(user(myDetails)))
                     .andExpect(status().isForbidden());
         }


### PR DESCRIPTION
[refactor] changePostArchive 파라미터 및 엔드포인트 변경
* ArchiveService: changePostArchive(userId, archiveId, postId) → changePostArchive(userId, postId, nickname, slug)
* ArchiveServiceImpl: findArchiveById() 제거, findArchiveByNicknameAndSlug() 사용으로 변경
* ArchiveUserController: PATCH /{archiveId}/post/{postId} → /{nickname}/{slug}/post/{postId}
* ArchiveUserControllerDocs: archiveId 파라미터 → nickname, slug 파라미터로 교체

[feat] Archive 통합 테스트 게시글 배정 케이스 엔드포인트 반영
* ArchiveIntegrationTest: 게시글_아카이브_배정 URL 및 경로 변수 업데이트

[refactor] 역할별 조회 메서드 통합 및 archiveId → nickname+slug 식별 방식 전환
* ArchiveService: getPagedPostItemsByArchiveIdForGuest, getPagedPostItemsByUserIdAndArchiveIdForUser
  → getPagedPostItems(requesterId, nickname, slug, pageable) 단일 메서드로 통합
* getPagedItemsByNicknameForGuest 제거 (비회원 아카이브 목록 조회 불필요)
* getPagedItemsForUser → getPagedItems 이름 변경 (ForUser 접미사 제거)
* GuestController: GET /{archiveId}/posts → /{nickname}/{slug}/posts
* UserController: GET /{archiveId}/posts → /{nickname}/{slug}/posts

[feat] ArchiveIntegrationTest 아카이브 게시글 목록 권한 없음 케이스 추가
* 내_아카이브_게시글_목록_조회: 타인 아카이브 접근 시 403 검증 추가

[refactor] User 아카이브 게시글 목록 조회 엔드포인트 개선
* GET /api/user/archive/{nickname}/{slug}/posts → /{slug}/posts
* nickname은 userDetails.getUser().getNickname()으로 내부 조달
* ArchiveUserController, ArchiveUserControllerDocs, 통합 테스트 반영