### PR TITLE
[Post] 게시글 내 비디오 태그 지원 및 예외 처리 개선

### DIFF
--- a/src/main/java/com/sealog/backend/domain/feature/post/util/PostHtmlParser.java
+++ b/src/main/java/com/sealog/backend/domain/feature/post/util/PostHtmlParser.java
@@ -40,18 +40,18 @@ public class PostHtmlParser {
          */
         public String finalize(Set<Long> invalidIds) {
             Document copy = doc.clone();
-            for (Element img : copy.body().select("img")) {
-                img.removeAttr("src");
+            for (Element el : copy.body().select("img, video")) {
+                el.removeAttr("src");
 
-                String fileIdStr = img.attr("data-file-id");
+                String fileIdStr = el.attr("data-file-id");
                 if (!fileIdStr.isEmpty()) {
                     try {
                         if (!invalidIds.isEmpty() && invalidIds.contains(Long.parseLong(fileIdStr))) {
-                            img.remove();
+                            el.remove();
                         }
                     } catch (NumberFormatException e) {
                         log.warn("data-file-id 파싱 실패로 태그 제거: value={}", fileIdStr);
-                        img.remove();
+                        el.remove();
                     }
                 }
             }
@@ -79,11 +79,11 @@ public class PostHtmlParser {
 
         // 2. 파일 ID 추출 (DOM 순회, 재파싱 없음)
         Set<Long> fileIds = new HashSet<>();
-        for (Element img : doc.body().select("img[data-file-id]")) {
+        for (Element el : doc.body().select("img[data-file-id], video[data-file-id]")) {
             try {
-                fileIds.add(Long.parseLong(img.attr("data-file-id")));
+                fileIds.add(Long.parseLong(el.attr("data-file-id")));
             } catch (NumberFormatException e) {
-                log.warn("data-file-id 파싱 실패: value={}", img.attr("data-file-id"));
+                log.warn("data-file-id 파싱 실패: value={}", el.attr("data-file-id"));
             }
         }
 
@@ -106,10 +106,10 @@ public class PostHtmlParser {
         }
 
         Document doc = Jsoup.parseBodyFragment(html);
-        Elements images = doc.select("img[data-file-id]");
+        Elements mediaElements = doc.select("img[data-file-id], video[data-file-id]");
 
-        for (Element img : images) {
-            String fileIdStr = img.attr("data-file-id");
+        for (Element el : mediaElements) {
+            String fileIdStr = el.attr("data-file-id");
             try {
                 fileIds.add(Long.parseLong(fileIdStr));
             } catch (NumberFormatException e) {
@@ -137,18 +137,18 @@ public class PostHtmlParser {
         Document doc = Jsoup.parseBodyFragment(html);
         doc.outputSettings().prettyPrint(false);
 
-        Elements images = doc.select("img[data-file-id]");
+        Elements mediaElements = doc.select("img[data-file-id], video[data-file-id]");
         int removedCount = 0;
-        for (Element img : images) {
+        for (Element el : mediaElements) {
             try {
-                Long fileId = Long.parseLong(img.attr("data-file-id"));
+                Long fileId = Long.parseLong(el.attr("data-file-id"));
                 if (invalidFileIds.contains(fileId)) {
-                    img.remove();
+                    el.remove();
                     removedCount++;
                 }
             } catch (NumberFormatException e) {
-                log.warn("data-file-id 파싱 실패로 태그 제거: value={}", img.attr("data-file-id"));
-                img.remove();
+                log.warn("data-file-id 파싱 실패로 태그 제거: value={}", el.attr("data-file-id"));
+                el.remove();
                 removedCount++;
             }
         }
@@ -174,19 +174,19 @@ public class PostHtmlParser {
         doc.outputSettings().prettyPrint(false);
 
         int removedCount = 0;
-        for (Element img : doc.select("img")) {
-            img.removeAttr("src");
+        for (Element el : doc.select("img, video")) {
+            el.removeAttr("src");
 
-            String fileIdStr = img.attr("data-file-id");
+            String fileIdStr = el.attr("data-file-id");
             if (!fileIdStr.isEmpty() && !invalidFileIds.isEmpty()) {
                 try {
                     if (invalidFileIds.contains(Long.parseLong(fileIdStr))) {
-                        img.remove();
+                        el.remove();
                         removedCount++;
                     }
                 } catch (NumberFormatException e) {
                     log.warn("data-file-id 파싱 실패로 태그 제거: value={}", fileIdStr);
-                    img.remove();
+                    el.remove();
                     removedCount++;
                 }
             }
@@ -211,12 +211,12 @@ public class PostHtmlParser {
         Document doc = Jsoup.parseBodyFragment(html);
         doc.outputSettings().prettyPrint(false);
 
-        Elements images = doc.select("img[src]");
-        for (Element img : images) {
-            img.removeAttr("src");
+        Elements mediaElements = doc.select("img[src], video[src]");
+        for (Element el : mediaElements) {
+            el.removeAttr("src");
         }
 
-        log.debug("src 속성 제거 완료: 대상 img 수={}", images.size());
+        log.debug("src 속성 제거 완료: 대상 수={}", mediaElements.size());
         return doc.body().html();
     }
 
@@ -237,14 +237,14 @@ public class PostHtmlParser {
         Document doc = Jsoup.parseBodyFragment(html);
         doc.outputSettings().prettyPrint(false);
 
-        Elements images = doc.select("img[data-file-path]");
-        for (Element img : images) {
-            String filePath = img.attr("data-file-path");
+        Elements mediaElements = doc.select("img[data-file-path], video[data-file-path]");
+        for (Element el : mediaElements) {
+            String filePath = el.attr("data-file-path");
             String src = filePath.startsWith("/") ? base + filePath : base + "/" + filePath;
-            img.attr("src", src);
+            el.attr("src", src);
         }
 
-        log.debug("src 속성 주입 완료: 대상 img 수={}", images.size());
+        log.debug("src 속성 주입 완료: 대상 수={}", mediaElements.size());
         return doc.body().html();
     }
 

--- a/src/main/java/com/sealog/backend/domain/feature/post/util/PostHtmlSanitizer.java
+++ b/src/main/java/com/sealog/backend/domain/feature/post/util/PostHtmlSanitizer.java
@@ -21,6 +21,7 @@ public class PostHtmlSanitizer {
      *       dd, dfn, div, dl, dt, em, figcaption, figure, h1-h6, header,
      *       hr, i, img, li, ol, p, pre, q, small, span, strike, strong,
      *       sub, sup, table, tbody, td, tfoot, th, thead, tr, u, ul
+     *       video
      *
      * 차단: script, style, iframe, form, input 등 → 400 Bad Request
      */
@@ -29,11 +30,15 @@ public class PostHtmlSanitizer {
             "dd", "dfn", "div", "dl", "dt", "em", "figcaption", "figure",
             "h1", "h2", "h3", "h4", "h5", "h6", "header", "hr", "i", "img",
             "li", "ol", "p", "pre", "q", "small", "span", "strike", "strong",
-            "sub", "sup", "table", "tbody", "td", "tfoot", "th", "thead", "tr", "u", "ul"
+            "sub", "sup", "table", "tbody", "td", "tfoot", "th", "thead", "tr", "u", "ul",
+            "video"
     );
 
     private static final Safelist SAFELIST = Safelist.relaxed()
-            .addAttributes("img", "data-file-id", "data-file-path");
+            .addAttributes("img", "data-file-id", "data-file-path")
+            .addTags("video")
+            .addAttributes("video", "src", "controls", "width", "height", "data-file-id", "data-file-path")
+            .addProtocols("video", "src", "https");
 
     private static final Document.OutputSettings OUTPUT_SETTINGS =
             new Document.OutputSettings().prettyPrint(false);

--- a/src/main/java/com/sealog/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sealog/backend/global/exception/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -26,6 +27,7 @@ public class GlobalExceptionHandler {
     public CustomResponse<Void> handleBusinessException(CustomException e, HttpServletResponse response) {
         log.error("Business Exception: {}", e.getMessage());
         response.setStatus(e.getStatus().value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         return CustomResponse.error(e.getMessage(), e.getStatus().value());
     }
 
@@ -78,6 +80,16 @@ public class GlobalExceptionHandler {
                 "요청을 처리할 수 없습니다. 중복된 값이거나 유효하지 않은 요청입니다.",
                 HttpStatus.CONFLICT.value()
         );
+    }
+
+    /**
+     * 클라이언트가 연결을 끊었을 때 (영상 스트리밍 seek, 탭 이동 등 정상 동작)
+     * 응답을 쓰지 않고 무시합니다.
+     */
+    @ExceptionHandler(org.apache.catalina.connector.ClientAbortException.class)
+    @ResponseStatus(HttpStatus.OK)
+    public void handleClientAbort(org.apache.catalina.connector.ClientAbortException e) {
+        log.debug("Client disconnected: {}", e.getMessage());
     }
 
     /**


### PR DESCRIPTION
[feat] 게시글 본문 내 비디오(video) 태그 지원 추가
- PostHtmlParser에서 video 태그의 src, data-file-id, data-file-path 처리 로직 추가
- PostHtmlSanitizer 세이프리스트에 video 태그 및 관련 속성(controls, width, height 등) 허용

[fix] 비디오 스트리밍 및 응답 처리 안정성 향상
- GlobalExceptionHandler에 ClientAbortException 처리 추가 (스트리밍 중 중단 시 로그 레벨 조정)
- 비즈니스 예외 발생 시 응답 Content-Type을 APPLICATION_JSON으로 명시적 설정

[refactor] HTML 파싱 로직 범용성 개선
- 이미지 전용으로 작성된 변수 및 로직을 미디어 태그(img, video) 공통 처리 방식으로 변경