### PR TITLE
[Test] 테스트 컨테이너를 Spring 컨텍스트 Bean으로 등록하도록 전환

### DIFF
--- a/src/test/java/com/sealog/backend/support/base/config/TestGlobalConfig.java
+++ b/src/test/java/com/sealog/backend/support/base/config/TestGlobalConfig.java
@@ -1,9 +1,10 @@
 package com.sealog.backend.support.base.config;
 
 import com.sealog.backend.support.component.TestTextGenerator;
-import com.sealog.backend.support.component.TestDataFactory;
 import com.sealog.backend.support.extension.ExecutionTimeExtension;
+import org.junit.jupiter.api.ClassOrderer;
 import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.TestClassOrder;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.context.annotation.Import;
@@ -13,9 +14,10 @@ import org.springframework.test.context.ActiveProfiles;
  * 모든 테스트가 공용으로 사용할 설정을 정의하는 추상 클래스
  */
 @ActiveProfiles("test")
-@Import({TestTextGenerator.class, TestDataFactory.class})
+@Import({TestTextGenerator.class})
 @ExtendWith(ExecutionTimeExtension.class) // 메소드 별 시간 측정
-@TestMethodOrder(MethodOrderer.OrderAnnotation.class) // @Order 기반 실행 순서
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class) // 메소드 실행 순서 보장
+@TestClassOrder(ClassOrderer.OrderAnnotation.class) // 클래스 내 @Nested 클래스 실행 순서 보장
 public abstract class TestGlobalConfig {
 
 }

--- a/src/test/java/com/sealog/backend/support/base/container/TestMariaDBContainer.java
+++ b/src/test/java/com/sealog/backend/support/base/container/TestMariaDBContainer.java
@@ -1,0 +1,30 @@
+package com.sealog.backend.support.base.container;
+
+import com.sealog.backend.support.base.container.legacy.TestContainer;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.testcontainers.containers.MariaDBContainer;
+
+@TestConfiguration(proxyBeanMethods = false)
+public class TestMariaDBContainer {
+
+    @Bean
+    @ServiceConnection
+    public MariaDBContainer<?> mariaDBContainer() {
+        return new MariaDBContainer<>(TestContainer.DEFAULT_IMAGE_DATABASE)
+                .withDatabaseName(TestContainer.DEFAULT_DATABASE_NAME)
+                .withUsername(TestContainer.DEFAULT_DATABASE_USERNAME)
+                .withPassword(TestContainer.DEFAULT_DATABASE_PASSWORD)
+                .withUrlParam("serverTimezone", "Asia/Seoul")
+                .withUrlParam("characterEncoding", "UTF-8")
+                .withCommand(
+                        "--innodb-flush-log-at-trx-commit=2",  // commit 시 fsync 제거 (OS 버퍼에 쓰기만)
+                        "--innodb-doublewrite=OFF",             // 이중 쓰기 버퍼 비활성화 (데이터 파일 쓰기 절반으로 감소, 운영 환경 비권장)
+                        "--innodb-buffer-pool-size=512M",       // dirty page 수용 공간 확대 (DB 버퍼 공간 증가로 삽입 시간 개선)
+                        "--max-allowed-packet=128M",            // MariaDB로 전송하는 단일 패킷 최대 크기
+                        "--innodb-ft-min-token-size=2"          // 한글 2글자 검색을 위해 MariaDB 설정
+                );
+    }
+
+}

--- a/src/test/java/com/sealog/backend/support/base/container/TestRedisContainer.java
+++ b/src/test/java/com/sealog/backend/support/base/container/TestRedisContainer.java
@@ -1,0 +1,19 @@
+package com.sealog.backend.support.base.container;
+
+import com.sealog.backend.support.base.container.legacy.TestContainer;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.context.annotation.Bean;
+import org.testcontainers.containers.GenericContainer;
+
+@TestConfiguration(proxyBeanMethods = false)
+public class TestRedisContainer {
+
+    @Bean
+    @ServiceConnection(name = "redis")
+    public GenericContainer<?> redisContainer() {
+        return new GenericContainer<>(TestContainer.DEFAULT_IMAGE_REDIS)
+                .withExposedPorts(TestContainer.DEFAULT_REDIS_PORT);
+    }
+
+}

--- a/src/test/java/com/sealog/backend/support/base/container/legacy/TestContainer.java
+++ b/src/test/java/com/sealog/backend/support/base/container/legacy/TestContainer.java
@@ -1,4 +1,4 @@
-package com.sealog.backend.support.base.container;
+package com.sealog.backend.support.base.container.legacy;
 
 import lombok.experimental.UtilityClass;
 import org.springframework.test.context.DynamicPropertyRegistry;
@@ -20,7 +20,7 @@ public class TestContainer {
     public static final int DEFAULT_REDIS_PORT = 6379;
 
     // 컨테이너 상수
-    private static final MariaDBContainer<?> MARIA_DB =
+    public static final MariaDBContainer<?> MARIA_DB =
             new MariaDBContainer<>(TestContainer.DEFAULT_IMAGE_DATABASE)
                     .withDatabaseName(TestContainer.DEFAULT_DATABASE_NAME)
                     .withUsername(TestContainer.DEFAULT_DATABASE_USERNAME)
@@ -33,7 +33,7 @@ public class TestContainer {
                             "--innodb-ft-min-token-size=2"          // 한글 2글자 검색을 위해 MariaDB 설정
                     );
 
-    private static final GenericContainer<?> REDIS =
+    public static final GenericContainer<?> REDIS =
             new GenericContainer<>(TestContainer.DEFAULT_IMAGE_REDIS)
                     .withExposedPorts(TestContainer.DEFAULT_REDIS_PORT);
 

--- a/src/test/java/com/sealog/backend/support/base/container/legacy/TestIntegrationContainer.java
+++ b/src/test/java/com/sealog/backend/support/base/container/legacy/TestIntegrationContainer.java
@@ -1,4 +1,4 @@
-package com.sealog.backend.support.base.container;
+package com.sealog.backend.support.base.container.legacy;
 
 import com.sealog.backend.support.base.config.TestGlobalConfig;
 import org.springframework.test.context.DynamicPropertyRegistry;

--- a/src/test/java/com/sealog/backend/support/base/container/legacy/TestIntegrationContainerV2.java
+++ b/src/test/java/com/sealog/backend/support/base/container/legacy/TestIntegrationContainerV2.java
@@ -1,0 +1,27 @@
+package com.sealog.backend.support.base.container.legacy;
+
+import com.sealog.backend.support.base.config.TestGlobalConfig;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.test.annotation.DirtiesContext;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.MariaDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * [비교용] @Testcontainers + static @Container 기반 컨테이너 관리 클래스
+ */
+@Testcontainers
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+public abstract class TestIntegrationContainerV2 extends TestGlobalConfig {
+
+    // 컨테이너 (static: @Testcontainers 가 BeforeAll/AfterAll 에서 클래스마다 기동·종료)
+    @Container
+    @ServiceConnection
+    static final MariaDBContainer<?> MARIA_DB = TestContainer.MARIA_DB;
+
+    @Container
+    @ServiceConnection
+    static final GenericContainer<?> REDIS = TestContainer.REDIS;
+
+}

--- a/src/test/java/com/sealog/backend/support/base/container/legacy/TestPersistenceContainer.java
+++ b/src/test/java/com/sealog/backend/support/base/container/legacy/TestPersistenceContainer.java
@@ -1,4 +1,4 @@
-package com.sealog.backend.support.base.container;
+package com.sealog.backend.support.base.container.legacy;
 
 import com.sealog.backend.support.base.config.TestGlobalConfig;
 import org.springframework.test.context.DynamicPropertyRegistry;

--- a/src/test/java/com/sealog/backend/support/base/test/IntegrationTest.java
+++ b/src/test/java/com/sealog/backend/support/base/test/IntegrationTest.java
@@ -1,20 +1,20 @@
 package com.sealog.backend.support.base.test;
 
 
-import com.sealog.backend.support.base.container.TestIntegrationContainer;
+import com.sealog.backend.infra.orm.querydsl.QueryDslConfig;
+import com.sealog.backend.support.base.config.TestGlobalConfig;
+import com.sealog.backend.support.base.container.*;
 import com.sealog.backend.support.component.TestDataFactory;
 import com.sealog.backend.support.constant.TestMode;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.redis.core.StringRedisTemplate;
-import org.springframework.test.web.servlet.MockMvc;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 
 /**
  * 통합 테스트 베이스 클래스
@@ -22,12 +22,15 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 
 @Tag(TestMode.INTEGRATION)
 @AutoConfigureMockMvc
-@SpringBootTest()
-public abstract class IntegrationTest extends TestIntegrationContainer {
+@Import({TestDataFactory.class, QueryDslConfig.class, TestMariaDBContainer.class, TestRedisContainer.class})
+@SpringBootTest
+public abstract class IntegrationTest extends TestGlobalConfig {
 
+    // 사용 의존성
     @Autowired protected TestDataFactory testDataFactory;
     @Autowired protected StringRedisTemplate stringRedisTemplate;
 
+    // warmUp 수행 여부
     private static volatile boolean warmedUp = false;
 
     @BeforeEach
@@ -46,4 +49,7 @@ public abstract class IntegrationTest extends TestIntegrationContainer {
             stringRedisTemplate.getConnectionFactory().getConnection().serverCommands().flushAll();
         }
     }
+
+
+
 }

--- a/src/test/java/com/sealog/backend/support/base/test/PersistenceTest.java
+++ b/src/test/java/com/sealog/backend/support/base/test/PersistenceTest.java
@@ -1,7 +1,8 @@
 package com.sealog.backend.support.base.test;
 
 import com.sealog.backend.infra.orm.querydsl.QueryDslConfig;
-import com.sealog.backend.support.base.container.TestPersistenceContainer;
+import com.sealog.backend.support.base.config.TestGlobalConfig;
+import com.sealog.backend.support.base.container.TestMariaDBContainer;
 import com.sealog.backend.support.component.TestDataFactory;
 import com.sealog.backend.support.constant.TestMode;
 import org.junit.jupiter.api.*;
@@ -22,18 +23,24 @@ import org.springframework.test.context.jdbc.Sql;
 @Tag(TestMode.PERSISTENCE)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @DataJpaTest
-@Import({TestDataFactory.class, QueryDslConfig.class})
+@Import({TestDataFactory.class, QueryDslConfig.class, TestMariaDBContainer.class})
 @Sql(
         // Spring 컨텍스트 로딩(=JPA 테이블 생성) 완료 이후, 첫 번째 테스트 메서드 실행 이전에 실행
         scripts = "/sql/index.sql",
         executionPhase = Sql.ExecutionPhase.BEFORE_TEST_CLASS
 )
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE) // 테스트에선 Testcontainer를 무시하고 내장 H2로 교체 시도
-public abstract class PersistenceTest extends TestPersistenceContainer {
+public abstract class PersistenceTest extends TestGlobalConfig /*extends TestPersistenceContainer*/ {
 
     // 사용 의존성
-    @Autowired
-    private TestDataFactory testDataFactory;
+    @Autowired protected TestDataFactory testDataFactory;
+
+    // warmUp 수행 여부
+    private static volatile boolean warmedUp = false;
+
+    @Test
+    void warmup() {
+    }
 
     /**
      * 각 테스트 클래스 종료 후, 테이블 재생성 (TRUNCATE)

--- a/src/test/java/com/sealog/backend/support/component/TestDataFactory.java
+++ b/src/test/java/com/sealog/backend/support/component/TestDataFactory.java
@@ -13,7 +13,7 @@ import com.sealog.backend.domain.feature.category.repository.CategoryRepository;
 import com.sealog.backend.domain.feature.user.entity.User;
 import com.sealog.backend.domain.feature.user.enums.UserRole;
 import com.sealog.backend.domain.feature.user.repository.UserRepository;
-import com.sealog.backend.support.base.container.TestContainer;
+import com.sealog.backend.support.base.container.legacy.TestContainer;
 import com.sealog.backend.support.constant.TestSql;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.test.context.TestComponent;
@@ -27,7 +27,6 @@ import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 
 /**
@@ -74,6 +73,10 @@ public class TestDataFactory {
         // 3. FK Constraint 활성화
         jdbcTemplate.execute(TestSql.FOREIGN_KEY_CHECKS_ACTIVATION);
     }
+
+    // =========================================================
+    // 헬퍼 함수
+    // =========================================================
 
 
     // =========================================================


### PR DESCRIPTION
[refactor] 컨테이너 관리 방식을 @TestConfiguration + @ServiceConnection 기반으로 전환
- TestMariaDBContainer, TestRedisContainer: @Bean + @ServiceConnection으로 컨테이너를 Spring 컨텍스트에 등록하여 Spring Boot가 연결 정보를 자동 구성하도록 변경
- IntegrationTest: TestIntegrationContainer 상속 제거 → TestGlobalConfig 상속 + @Import({TestMariaDBContainer.class, TestRedisContainer.class})로 컨테이너 주입

[delete] 기존 컨테이너 클래스 legacy 패키지로 이동 (비교 보존용)
- TestContainer, TestIntegrationContainer, TestPersistenceContainer → legacy/ 이동
- TestIntegrationContainerV2 추가 (@Testcontainers + @Container 방식, 비교용)

[chore] TestGlobalConfig에 @TestClassOrder 추가
- @Nested 클래스 간 실행 순서 미보장 문제 해결